### PR TITLE
ChartGestures for swing and javafx

### DIFF
--- a/src/main/java/io/github/mzmine/chartbasics/ChartLogics.java
+++ b/src/main/java/io/github/mzmine/chartbasics/ChartLogics.java
@@ -1,0 +1,766 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.util.logging.Logger;
+import javax.swing.JPanel;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.Axis;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.entity.AxisEntity;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.entity.EntityCollection;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.CombinedRangeXYPlot;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.ui.RectangleEdge;
+import org.jfree.data.Range;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+
+/**
+ * Collection of methods for JFreeCharts <br>
+ * Calculate mouseXY to plotXY <br>
+ * Calc width and height for plots where domain and range axis share the same dimensions <br>
+ * Zoom and shift axes by absolute or relative values
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartLogics {
+  private static Logger logger = Logger.getLogger(ChartLogics.class.getName());
+
+  /**
+   * Translates mouse coordinates to chart coordinates (xy-axis)
+   * 
+   * @param myChart
+   * @param mouseX
+   * @param mouseY
+   * @return Range as chart coordinates
+   * @throws Exception
+   */
+  public static Point2D mouseXYToPlotXY(ChartPanel myChart, double mouseX, double mouseY)
+      throws Exception {
+    return mouseXYToPlotXY(myChart, (int) mouseX, (int) mouseY);
+  }
+
+  /**
+   * Translates mouse coordinates to chart coordinates (xy-axis)
+   * 
+   * @param myChart
+   * @param mouseX
+   * @param mouseY
+   * @return Range as chart coordinates
+   * @throws Exception
+   */
+  public static Point2D mouseXYToPlotXY(ChartPanel myChart, int mouseX, int mouseY)
+      throws Exception {
+    Point2D p = myChart.translateScreenToJava2D(new Point(mouseX, mouseY));
+
+    XYPlot plot = null;
+    // find plot as parent of axis
+    ChartEntity entity = findChartEntity(myChart, mouseX, mouseY);
+    if (entity instanceof AxisEntity) {
+      Axis a = ((AxisEntity) entity).getAxis();
+      if (a.getPlot() instanceof XYPlot)
+        plot = (XYPlot) a.getPlot();
+    }
+
+    ChartRenderingInfo info = myChart.getChartRenderingInfo();
+    int subplot = info.getPlotInfo().getSubplotIndex(p);
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+    if (subplot != -1)
+      dataArea = info.getPlotInfo().getSubplotInfo(subplot).getDataArea();
+
+    if (plot == null)
+      plot = findXYSubplot(myChart.getChart(), info, p.getX(), p.getY());
+
+    // coordinates
+    double cx = 0;
+    double cy = 0;
+    if (plot != null) {
+      // find axis
+      ValueAxis domainAxis = plot.getDomainAxis();
+      ValueAxis rangeAxis = plot.getRangeAxis();
+      RectangleEdge domainAxisEdge = plot.getDomainAxisEdge();
+      RectangleEdge rangeAxisEdge = plot.getRangeAxisEdge();
+      // parent?
+      if (domainAxis == null && plot.getParent() != null && plot.getParent() instanceof XYPlot) {
+        XYPlot pp = ((XYPlot) plot.getParent());
+        domainAxis = pp.getDomainAxis();
+        domainAxisEdge = pp.getDomainAxisEdge();
+      }
+      if (rangeAxis == null && plot.getParent() != null && plot.getParent() instanceof XYPlot) {
+        XYPlot pp = ((XYPlot) plot.getParent());
+        rangeAxis = pp.getRangeAxis();
+        rangeAxisEdge = pp.getRangeAxisEdge();
+      }
+
+      if (domainAxis != null)
+        cx = domainAxis.java2DToValue(p.getX(), dataArea, domainAxisEdge);
+      if (rangeAxis != null)
+        cy = rangeAxis.java2DToValue(p.getY(), dataArea, rangeAxisEdge);
+    } else {
+      throw new Exception("no xyplot found");
+    }
+    return new Point2D.Double(cx, cy);
+
+  }
+
+  /**
+   * Subplot or main plot at point
+   * 
+   * @param chart
+   * @param info
+   * @param mouseX
+   * @param mouseY
+   * @return
+   */
+  public static XYPlot findXYSubplot(JFreeChart chart, ChartRenderingInfo info, double mouseX,
+      double mouseY) {
+    int subplot = info.getPlotInfo().getSubplotIndex(new Point2D.Double(mouseX, mouseY));
+    XYPlot plot = null;
+    if (subplot != -1) {
+      if (chart.getPlot() instanceof CombinedDomainXYPlot)
+        plot = (XYPlot) ((CombinedDomainXYPlot) chart.getPlot()).getSubplots().get(subplot);
+      else if (chart.getPlot() instanceof CombinedRangeXYPlot)
+        plot = (XYPlot) ((CombinedRangeXYPlot) chart.getPlot()).getSubplots().get(subplot);
+    }
+
+    if (plot == null && chart.getPlot() instanceof XYPlot)
+      plot = (XYPlot) chart.getPlot();
+
+    return plot;
+  }
+
+  /**
+   * Find chartentities like JFreeChartEntity, AxisEntity, PlotEntity, TitleEntity, XY...
+   * 
+   * @param chart
+   * @param mx mouse coordinates
+   * @param my mouse coordinates
+   * @return
+   */
+  public static ChartEntity findChartEntity(ChartPanel chart, double mx, double my) {
+    // TODO check if insets were needed
+    // coordinates to find chart entities
+    Insets insets = chart.getInsets();
+    int x = (int) ((mx - insets.left) / chart.getScaleX());
+    int y = (int) ((my - insets.top) / chart.getScaleY());
+
+    ChartRenderingInfo info = chart.getChartRenderingInfo();
+    ChartEntity entity = null;
+    if (info != null) {
+      EntityCollection entities = info.getEntityCollection();
+      if (entities != null) {
+        entity = entities.getEntity(x, y);
+      }
+    }
+    return entity;
+  }
+
+  /**
+   * Translates screen (pixel) values to plot values
+   * 
+   * @param myChart
+   * @return width in data space for x and y
+   * @throws Exception
+   */
+  public static Point2D screenValueToPlotValue(ChartPanel myChart, int val) throws Exception {
+    Point2D p = mouseXYToPlotXY(myChart, 0, 0);
+    Point2D p2 = mouseXYToPlotXY(myChart, val, val);
+    // inverted y
+    return new Point2D.Double(p2.getX() - p.getX(), p.getY() - p2.getY());
+  }
+
+
+  /**
+   * Data width to pixel width on screen
+   * 
+   * @param myChart
+   * @param dataWidth width of data
+   * @param axis for width calculation
+   * @return
+   */
+  public static double calcWidthOnScreen(ChartPanel myChart, double dataWidth, ValueAxis axis,
+      RectangleEdge axisEdge) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ChartRenderingInfo info = myChart.getChartRenderingInfo();
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+
+    double width2D = axis.lengthToJava2D(dataWidth, dataArea, axisEdge);
+
+    return width2D;
+  }
+
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width Domain and Range axes need to share
+   * the same unit (e.g. mm)
+   * 
+   * @param chart
+   * @param width
+   * @return
+   */
+  public static Dimension calcSizeForPlotWidth(ChartPanel myChart, double plotWidth) {
+    return calcSizeForPlotWidth(myChart, plotWidth, 4);
+  }
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width Domain and Range axes need to share
+   * the same unit (e.g. mm)
+   * 
+   * @param chart
+   * @param plotWidth
+   * @return
+   */
+  public static Dimension calcSizeForPlotWidth(ChartPanel myChart, double plotWidth,
+      int iterations) {
+    // ranges
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    Range x = domainAxis.getRange();
+    ValueAxis rangeAxis = plot.getRangeAxis();
+    Range y = rangeAxis.getRange();
+
+    // plot height is fixed
+    double plotHeight = plotWidth / x.getLength() * y.getLength();
+    return calcSizeForPlotSize(myChart, plotWidth, plotHeight, iterations);
+  }
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width and height
+   * 
+   * @param chart
+   * @param plotWidth
+   * @return
+   */
+  public static Dimension calcSizeForPlotSize(ChartPanel myChart, double plotWidth,
+      double plotHeight) {
+    return calcSizeForPlotSize(myChart, plotWidth, plotHeight, 4);
+  }
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width and height
+   * 
+   * @param chart
+   * @param plotWidth
+   * @return
+   */
+  public static Dimension calcSizeForPlotSize(ChartPanel myChart, double plotWidth,
+      double plotHeight, int iterations) {
+    makeChartResizable(myChart);
+
+    // estimate plotwidth / height
+    double estimatedChartWidth = plotWidth + 200;
+    double estimatedChartHeight = plotHeight + 200;
+
+    double lastW = estimatedChartWidth;
+    double lastH = estimatedChartHeight;
+
+    // paint and get closer
+    try {
+      for (int i = 0; i < iterations; i++) {
+        // paint on ghost panel with estimated height (if copy panel==true)
+        myChart.setSize((int) estimatedChartWidth, (int) estimatedChartHeight);
+        myChart.paintImmediately(myChart.getBounds());
+
+        // rendering info
+        ChartRenderingInfo info = myChart.getChartRenderingInfo();
+        Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+        Rectangle2D chartArea = info.getChartArea();
+
+        // // calc title space: will be added later to the right plot size
+        // double titleWidth = chartArea.getWidth()-dataArea.getWidth();
+        // double titleHeight = chartArea.getHeight()-dataArea.getHeight();
+
+        // calc width and height
+        estimatedChartWidth = estimatedChartWidth - dataArea.getWidth() + plotWidth;
+        estimatedChartHeight = estimatedChartHeight - dataArea.getHeight() + plotHeight;
+
+        if ((int) lastW == (int) estimatedChartWidth && (int) lastH == (int) estimatedChartHeight)
+          break;
+        else {
+          lastW = estimatedChartWidth;
+          lastH = estimatedChartHeight;
+        }
+      }
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
+
+    return new Dimension((int) estimatedChartWidth, (int) estimatedChartHeight);
+  }
+
+  /**
+   * calls this method twice (2 iterations) with an estimated chartHeight of 3*chartWidth Domain and
+   * Range axes need to share the same unit (e.g. mm)
+   * 
+   * @param myChart
+   * @param copyToNewPanel
+   * @param dataWidth width of data
+   * @param axis for width calculation
+   * @return
+   */
+  public static double calcHeightToWidth(ChartPanel myChart, double chartWidth,
+      boolean copyToNewPanel) {
+    return calcHeightToWidth(myChart, chartWidth, chartWidth * 3, 4, copyToNewPanel);
+  }
+
+  /**
+   * calculates the correct height with multiple iterations Domain and Range axes need to share the
+   * same unit (e.g. mm)
+   * 
+   * @param myChart
+   * @param copyToNewPanel
+   * @param dataWidth width of data
+   * @param axis for width calculation
+   * @return
+   */
+  public static double calcHeightToWidth(ChartPanel myChart, double chartWidth,
+      double estimatedHeight, int iterations, boolean copyToNewPanel) {
+    // if(myChart.getChartRenderingInfo()==null ||
+    // myChart.getChartRenderingInfo().getChartArea()==null ||
+    // myChart.getChartRenderingInfo().getChartArea().getWidth()==0)
+    // result
+    double height = estimatedHeight;
+    double lastH = height;
+
+    makeChartResizable(myChart);
+
+    // paint on a ghost panel
+    JPanel parent = (JPanel) myChart.getParent();
+    JPanel p = copyToNewPanel ? new JPanel() : parent;
+    if (copyToNewPanel)
+      p.add(myChart, BorderLayout.CENTER);
+    try {
+      for (int i = 0; i < iterations; i++) {
+        // paint on ghost panel with estimated height (if copy panel==true)
+        myChart.setSize((int) chartWidth, (int) estimatedHeight);
+        myChart.paintImmediately(myChart.getBounds());
+
+        XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+        ChartRenderingInfo info = myChart.getChartRenderingInfo();
+        Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+        Rectangle2D chartArea = info.getChartArea();
+
+        // calc title space: will be added later to the right plot size
+        double titleWidth = chartArea.getWidth() - dataArea.getWidth();
+        double titleHeight = chartArea.getHeight() - dataArea.getHeight();
+
+        // calc right plot size with axis dim.
+        // real plot width is given by factor;
+        double realPW = chartWidth - titleWidth;
+
+        // ranges
+        ValueAxis domainAxis = plot.getDomainAxis();
+        org.jfree.data.Range x = domainAxis.getRange();
+        ValueAxis rangeAxis = plot.getRangeAxis();
+        org.jfree.data.Range y = rangeAxis.getRange();
+
+        // real plot height can be calculated by
+        double realPH = realPW / x.getLength() * y.getLength();
+
+        // the real height
+        height = realPH + titleHeight;
+
+        // for next iteration
+        estimatedHeight = height;
+        if ((int) lastH == (int) height)
+          break;
+        else
+          lastH = height;
+      }
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
+
+    if (copyToNewPanel) {
+      // reset to frame
+      p.removeAll();
+      parent.add(myChart);
+    }
+
+    return height;
+  }
+
+  /**
+   * Removes draw size restrictions
+   * 
+   * @param myChart
+   */
+  public static void makeChartResizable(ChartPanel myChart) {
+    myChart.setMaximumDrawWidth(1000000000);
+    myChart.setMinimumDrawWidth(0);
+    myChart.setMaximumDrawHeight(1000000000);
+    myChart.setMinimumDrawHeight(0);
+  }
+
+  /**
+   * 
+   * Domain and Range axes need to share the same unit (e.g. mm)
+   * 
+   * @param myChart
+   * @return
+   */
+  public static double calcWidthToHeight(ChartPanel myChart, double chartHeight) {
+    makeChartResizable(myChart);
+    // paint on a ghost panel
+    JPanel parent = (JPanel) myChart.getParent();
+    JPanel p = new JPanel();
+    p.removeAll();
+    p.add(myChart, BorderLayout.CENTER);
+    p.setBounds(myChart.getBounds());
+    myChart.paintImmediately(myChart.getBounds());
+    p.removeAll();
+    parent.add(myChart);
+
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ChartRenderingInfo info = myChart.getChartRenderingInfo();
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+    Rectangle2D chartArea = info.getChartArea();
+
+
+    // calc title space: will be added later to the right plot size
+    double titleWidth = chartArea.getWidth() - dataArea.getWidth();
+    double titleHeight = chartArea.getHeight() - dataArea.getHeight();
+
+    // calc right plot size with axis dim.
+    // real plot width is given by factor;
+    double realPH = chartHeight - titleHeight;
+
+    // ranges
+    ValueAxis domainAxis = plot.getDomainAxis();
+    org.jfree.data.Range x = domainAxis.getRange();
+    ValueAxis rangeAxis = plot.getRangeAxis();
+    org.jfree.data.Range y = rangeAxis.getRange();
+
+    // real plot height can be calculated by
+    double realPW = realPH / y.getLength() * x.getLength();
+
+    double width = realPW + titleWidth;
+
+    return width;
+  }
+
+  /**
+   * Returns dimensions for limiting factor width or height
+   * 
+   * @param myChart
+   * @return
+   */
+  public static Dimension calcMaxSize(ChartPanel myChart, double chartWidth, double chartHeight) {
+    makeChartResizable(myChart);
+    // paint on a ghost panel
+    JPanel parent = (JPanel) myChart.getParent();
+    JPanel p = new JPanel();
+    p.removeAll();
+    p.add(myChart, BorderLayout.CENTER);
+    p.setBounds(myChart.getBounds());
+    myChart.paintImmediately(myChart.getBounds());
+    p.removeAll();
+    parent.add(myChart);
+
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ChartRenderingInfo info = myChart.getChartRenderingInfo();
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+    Rectangle2D chartArea = info.getChartArea();
+
+
+    // calc title space: will be added later to the right plot size
+    double titleWidth = chartArea.getWidth() - dataArea.getWidth();
+    double titleHeight = chartArea.getHeight() - dataArea.getHeight();
+
+    // calculatig width for max height
+
+    // calc right plot size with axis dim.
+    // real plot width is given by factor;
+    double realPH = chartHeight - titleHeight;
+
+    // ranges
+    ValueAxis domainAxis = plot.getDomainAxis();
+    org.jfree.data.Range x = domainAxis.getRange();
+    ValueAxis rangeAxis = plot.getRangeAxis();
+    org.jfree.data.Range y = rangeAxis.getRange();
+
+    // real plot height can be calculated by
+    double realPW = realPH / y.getLength() * x.getLength();
+
+    double width = realPW + titleWidth;
+    // if width is higher than given chartWidth then calc height for chartWidth
+    if (width > chartWidth) {
+      // calc right plot size with axis dim.
+      // real plot width is given by factor;
+      realPW = chartWidth - titleWidth;
+
+      // real plot height can be calculated by
+      realPH = realPW / x.getLength() * y.getLength();
+
+      double height = realPH + titleHeight;
+      // Return size
+      return new Dimension((int) chartWidth, (int) height);
+    } else {
+      // Return size
+      return new Dimension((int) width, (int) chartHeight);
+    }
+  }
+
+
+
+  /**
+   * 
+   * @param myChart
+   * @return Range the domainAxis zoom (X-axis)
+   */
+  public static Range getZoomDomainAxis(ChartPanel myChart) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+
+    return new Range(domainAxis.getLowerBound(), domainAxis.getUpperBound());
+  }
+
+  /**
+   * Zoom into a chart panel
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void setZoomDomainAxis(ChartPanel myChart, Range zoom, boolean autoRangeY) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    setZoomAxis(domainAxis, keepRangeWithinAutoBounds(domainAxis, zoom));
+
+    if (autoRangeY) {
+      autoRangeAxis(myChart);
+    }
+  }
+
+  /**
+   * Zoom into a chart panel
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void setZoomAxis(ValueAxis axis, Range zoom) {
+    axis.setRange(zoom);
+  }
+
+
+  /**
+   * Auto range the range axis
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void autoRangeAxis(ChartPanel myChart) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
+    // trick. Otherwise auto range will fail sometimes
+    rangeAxis.setRange(rangeAxis.getRange());
+    rangeAxis.setAutoRangeIncludesZero(true);
+    myChart.restoreAutoRangeBounds();
+  }
+
+  /**
+   * Auto range the range axis
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void autoDomainAxis(ChartPanel myChart) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    NumberAxis axis = (NumberAxis) plot.getDomainAxis();
+    // trick. Otherwise auto range will fail sometimes
+    axis.setRange(axis.getRange());
+    axis.setAutoRangeIncludesZero(false);
+    myChart.restoreAutoDomainBounds();
+  }
+
+  /**
+   * Auto range the axis
+   * 
+   * @param axis
+   */
+  public static void autoAxis(ValueAxis axis) {
+    axis.resizeRange(0);
+  }
+
+  public static void autoAxes(ChartPanel cp) {
+    autoRangeAxis(cp);
+    autoDomainAxis(cp);
+  }
+
+  /**
+   * Move a chart by a percentage x-offset if xoffset is <0 the shift will be negativ (xoffset>0
+   * results in a positive shift)
+   * 
+   * @param myChart
+   * @param xoffset in percent
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void offsetDomainAxis(ChartPanel myChart, double xoffset, boolean autoRangeY) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    // apply offset on x
+    double distance = (domainAxis.getUpperBound() - domainAxis.getLowerBound()) * xoffset;
+
+    Range range =
+        new Range(domainAxis.getLowerBound() + distance, domainAxis.getUpperBound() + distance);
+    setZoomDomainAxis(myChart, keepRangeWithinAutoBounds(domainAxis, range), autoRangeY);
+  }
+
+  /**
+   * Apply an absolute offset to domain (x) axis and move it
+   * 
+   * @param myChart
+   * @param xoffset
+   * @param autoRangeY
+   */
+  public static void offsetDomainAxisAbsolute(ChartPanel myChart, double xoffset,
+      boolean autoRangeY) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    // apply offset on x
+
+    Range range =
+        new Range(domainAxis.getLowerBound() + xoffset, domainAxis.getUpperBound() + xoffset);
+    setZoomDomainAxis(myChart, keepRangeWithinAutoBounds(domainAxis, range), autoRangeY);
+  }
+
+  /**
+   * Apply an absolute offset to an axis and move it
+   * 
+   * @param myChart
+   * @param offset
+   */
+  public static void offsetAxisAbsolute(ValueAxis axis, double offset) {
+    Range range = new Range(axis.getLowerBound() + offset, axis.getUpperBound() + offset);
+    setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+  }
+
+  /**
+   * Apply an relative offset to an axis and move it. LowerBound and UpperBound are defined by
+   * {@link ValueAxis#getDefaultAutoRange()}
+   * 
+   * @param myChart
+   * @param offset percentage
+   */
+  public static void offsetAxis(ValueAxis axis, double offset) {
+    double distance = (axis.getUpperBound() - axis.getLowerBound()) * offset;
+    Range range = new Range(axis.getLowerBound() + distance, axis.getUpperBound() + distance);
+    setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+  }
+
+  public static Range keepRangeWithinAutoBounds(ValueAxis axis, Range range) {
+    // keep within auto range bounds
+    // Range auto = axis.getDefaultAutoRange();
+    // if(range.getLowerBound()<auto.getLowerBound()){
+    // double negative = range.getLowerBound()-auto.getLowerBound();
+    // range = new Range(auto.getLowerBound(), range.getUpperBound()-negative);
+    // }
+    // if(range.getUpperBound()>auto.getUpperBound()) {
+    // double positive = range.getUpperBound()-auto.getUpperBound();
+    // range = new Range(range.getLowerBound()-positive, auto.getUpperBound());
+    // }
+    return range;
+  }
+
+  /**
+   * Zoom in (negative yzoom) or zoom out of range axis.
+   * 
+   * @param myChart
+   * @param yzoom percentage zoom factor
+   * @param holdLowerBound if true only the upper bound will be zoomed
+   */
+  public static void zoomRangeAxis(JFreeChart myChart, double yzoom, boolean holdLowerBound) {
+    zoomAxis(myChart.getXYPlot().getRangeAxis(), yzoom, holdLowerBound);
+  }
+
+  /**
+   * Zoom in (negative zoom) or zoom out of axis.
+   * 
+   * @param myChart
+   * @param zoom percentage zoom factor
+   * @param holdLowerBound if true only the upper bound will be zoomed
+   */
+  public static void zoomAxis(ValueAxis axis, double zoom, boolean holdLowerBound) {
+    double lower = axis.getLowerBound();
+    double upper = axis.getUpperBound();
+    double dist = upper - lower;
+
+    if (holdLowerBound) {
+      if (zoom == 0)
+        return;
+      upper += dist * zoom;
+    } else {
+      lower -= dist * zoom / 2;
+      upper += dist * zoom / 2;
+    }
+
+    if (lower < upper) {
+      logger.info("Set zoom:" + lower + ", " + upper + " (keep lower:" + holdLowerBound + ")");
+      Range range = new Range(lower, upper);
+      setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+    }
+  }
+
+  /**
+   * Zoom in (negative zoom) or zoom out of axis.
+   * 
+   * @param myChart
+   * @param zoom percentage zoom factor
+   * @param start point on this range (first click/pressed event), used as center
+   */
+  public static void zoomAxis(ValueAxis axis, double zoom, double start) {
+    double lower = axis.getLowerBound();
+    double upper = axis.getUpperBound();
+    double dist = upper - lower;
+    double f = (start - lower) / dist;
+
+    lower -= dist * zoom * f;
+    upper += dist * zoom * (1 - f);
+
+    if (lower < upper) {
+      Range range = new Range(lower, upper);
+      setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+    }
+  }
+
+  /**
+   * 
+   * @param chartPanel
+   * @return
+   */
+  public static boolean isMouseZoomable(ChartPanel chartPanel) {
+    return chartPanel instanceof EChartPanel ? ((EChartPanel) chartPanel).isMouseZoomable()
+        : chartPanel.isRangeZoomable() && chartPanel.isDomainZoomable();
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/ChartLogicsFX.java
+++ b/src/main/java/io/github/mzmine/chartbasics/ChartLogicsFX.java
@@ -1,0 +1,755 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics;
+
+import java.awt.Dimension;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.util.logging.Logger;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.Axis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.entity.AxisEntity;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.entity.EntityCollection;
+import org.jfree.chart.fx.ChartCanvas;
+import org.jfree.chart.fx.ChartViewer;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.CombinedRangeXYPlot;
+import org.jfree.chart.plot.PlotRenderingInfo;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.plot.Zoomable;
+import org.jfree.chart.ui.RectangleEdge;
+import org.jfree.data.Range;
+
+/**
+ * Collection of methods for JFreeCharts <br>
+ * Calculate mouseXY to plotXY <br>
+ * Calc width and height for plots where domain and range axis share the same dimensions <br>
+ * Zoom and shift axes by absolute or relative values
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartLogicsFX {
+  private static Logger logger = Logger.getLogger(ChartLogicsFX.class.getName());
+
+  /**
+   * Translates mouse coordinates to chart coordinates (xy-axis)
+   * 
+   * @param myChart
+   * @param mouseX
+   * @param mouseY
+   * @return Range as chart coordinates
+   */
+  public static Point2D mouseXYToPlotXY(ChartViewer myChart, double mouseX, double mouseY) {
+    return mouseXYToPlotXY(myChart, (int) mouseX, (int) mouseY);
+  }
+
+  /**
+   * Translates mouse coordinates to chart coordinates (xy-axis)
+   * 
+   * @param myChart
+   * @param mouseX
+   * @param mouseY
+   * @return Range as chart coordinates (never null)
+   */
+  public static Point2D mouseXYToPlotXY(ChartViewer myChart, int mouseX, int mouseY) {
+    XYPlot plot = null;
+    // find plot as parent of axis
+    ChartEntity entity = findChartEntity(myChart.getCanvas(), mouseX, mouseY);
+    if (entity instanceof AxisEntity) {
+      Axis a = ((AxisEntity) entity).getAxis();
+      if (a.getPlot() instanceof XYPlot)
+        plot = (XYPlot) a.getPlot();
+    }
+
+    ChartRenderingInfo info = myChart.getRenderingInfo();
+    int subplot = info.getPlotInfo().getSubplotIndex(new Point2D.Double(mouseX, mouseY));
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+    if (subplot != -1)
+      dataArea = info.getPlotInfo().getSubplotInfo(subplot).getDataArea();
+
+    // find subplot or plot
+    if (plot == null)
+      plot = findXYSubplot(myChart.getChart(), info, mouseX, mouseY);
+
+    // coordinates
+    double cx = 0;
+    double cy = 0;
+    if (plot != null) {
+      // find axis
+      ValueAxis domainAxis = plot.getDomainAxis();
+      ValueAxis rangeAxis = plot.getRangeAxis();
+      RectangleEdge domainAxisEdge = plot.getDomainAxisEdge();
+      RectangleEdge rangeAxisEdge = plot.getRangeAxisEdge();
+      // parent?
+      if (domainAxis == null && plot.getParent() != null && plot.getParent() instanceof XYPlot) {
+        XYPlot pp = ((XYPlot) plot.getParent());
+        domainAxis = pp.getDomainAxis();
+        domainAxisEdge = pp.getDomainAxisEdge();
+      }
+      if (rangeAxis == null && plot.getParent() != null && plot.getParent() instanceof XYPlot) {
+        XYPlot pp = ((XYPlot) plot.getParent());
+        rangeAxis = pp.getRangeAxis();
+        rangeAxisEdge = pp.getRangeAxisEdge();
+      }
+
+      if (domainAxis != null)
+        cx = domainAxis.java2DToValue(mouseX, dataArea, domainAxisEdge);
+      if (rangeAxis != null)
+        cy = rangeAxis.java2DToValue(mouseY, dataArea, rangeAxisEdge);
+    }
+    return new Point2D.Double(cx, cy);
+  }
+
+  /**
+   * Find chartentities like JFreeChartEntity, AxisEntity, PlotEntity, TitleEntity, XY...
+   * 
+   * @param chart
+   * @return
+   */
+  public static ChartEntity findChartEntity(ChartCanvas chart, double mx, double my) {
+    // TODO check if insets were needed
+    // coordinates to find chart entities
+    int x = (int) (mx / chart.getScaleX());
+    int y = (int) (my / chart.getScaleY());
+
+    ChartRenderingInfo info = chart.getRenderingInfo();
+    ChartEntity entity = null;
+    if (info != null) {
+      EntityCollection entities = info.getEntityCollection();
+      if (entities != null) {
+        entity = entities.getEntity(x, y);
+      }
+    }
+    return entity;
+  }
+
+  /**
+   * Subplot or main plot at point
+   * 
+   * @param chart
+   * @param info
+   * @param mouseX
+   * @param mouseY
+   * @return
+   */
+  public static XYPlot findXYSubplot(JFreeChart chart, ChartRenderingInfo info, double mouseX,
+      double mouseY) {
+    int subplot = info.getPlotInfo().getSubplotIndex(new Point2D.Double(mouseX, mouseY));
+    XYPlot plot = null;
+    if (subplot != -1) {
+      if (chart.getPlot() instanceof CombinedDomainXYPlot)
+        plot = (XYPlot) ((CombinedDomainXYPlot) chart.getPlot()).getSubplots().get(subplot);
+      else if (chart.getPlot() instanceof CombinedRangeXYPlot)
+        plot = (XYPlot) ((CombinedRangeXYPlot) chart.getPlot()).getSubplots().get(subplot);
+    }
+    if (plot == null && chart.getPlot() instanceof XYPlot)
+      plot = (XYPlot) chart.getPlot();
+    return plot;
+  }
+
+  /**
+   * Translates screen (pixel) values to plot values
+   * 
+   * @param myChart
+   * @return width in data space for x and y
+   */
+  public static Point2D screenValueToPlotValue(ChartViewer myChart, int val) {
+    Point2D p = mouseXYToPlotXY(myChart, 0, 0);
+    Point2D p2 = mouseXYToPlotXY(myChart, val, val);
+    // inverted y
+    return new Point2D.Double(p2.getX() - p.getX(), p.getY() - p2.getY());
+  }
+
+
+  /**
+   * Data width to pixel width on screen
+   * 
+   * @param myChart
+   * @param dataWidth width of data
+   * @param axis for width calculation
+   * @return
+   */
+  public static double calcWidthOnScreen(ChartViewer myChart, double dataWidth, ValueAxis axis,
+      RectangleEdge axisEdge) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ChartRenderingInfo info = myChart.getRenderingInfo();
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+
+    // width 2D
+    return axis.lengthToJava2D(dataWidth, dataArea, axisEdge);
+  }
+
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width Domain and Range axes need to share
+   * the same unit (e.g. mm)
+   * 
+   * @param chart
+   * @param width
+   * @return
+   */
+  public static Dimension calcSizeForPlotWidth(ChartViewer myChart, double plotWidth) {
+    return calcSizeForPlotWidth(myChart, plotWidth, 4);
+  }
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width Domain and Range axes need to share
+   * the same unit (e.g. mm)
+   * 
+   * @param chart
+   * @param plotWidth
+   * @return
+   */
+  public static Dimension calcSizeForPlotWidth(ChartViewer myChart, double plotWidth,
+      int iterations) {
+    // ranges
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    Range x = domainAxis.getRange();
+    ValueAxis rangeAxis = plot.getRangeAxis();
+    Range y = rangeAxis.getRange();
+
+    // plot height is fixed
+    double plotHeight = plotWidth / x.getLength() * y.getLength();
+    return calcSizeForPlotSize(myChart, plotWidth, plotHeight, iterations);
+  }
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width and height
+   * 
+   * @param chart
+   * @param plotWidth
+   * @return
+   */
+  public static Dimension calcSizeForPlotSize(ChartViewer myChart, double plotWidth,
+      double plotHeight) {
+    return calcSizeForPlotSize(myChart, plotWidth, plotHeight, 4);
+  }
+
+  /**
+   * Calculates the size of a chart for a given fixed plot width and height
+   * 
+   * @param chart
+   * @param plotWidth
+   * @return
+   */
+  public static Dimension calcSizeForPlotSize(ChartViewer myChart, double plotWidth,
+      double plotHeight, int iterations) {
+    makeChartResizable(myChart);
+
+    // estimate plotwidth / height
+    double estimatedChartWidth = plotWidth + 200;
+    double estimatedChartHeight = plotHeight + 200;
+
+    double lastW = estimatedChartWidth;
+    double lastH = estimatedChartHeight;
+
+    // paint and get closer
+    try {
+      for (int i = 0; i < iterations; i++) {
+        // paint on ghost panel with estimated height (if copy panel==true)
+        myChart.getCanvas().setWidth((int) estimatedChartWidth);
+        myChart.getCanvas().setHeight((int) estimatedChartHeight);
+        myChart.getCanvas().draw();
+
+        // rendering info
+        ChartRenderingInfo info = myChart.getRenderingInfo();
+        Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+        Rectangle2D chartArea = info.getChartArea();
+
+        // // calc title space: will be added later to the right plot size
+        // double titleWidth = chartArea.getWidth()-dataArea.getWidth();
+        // double titleHeight = chartArea.getHeight()-dataArea.getHeight();
+
+        // calc width and height
+        estimatedChartWidth = estimatedChartWidth - dataArea.getWidth() + plotWidth;
+        estimatedChartHeight = estimatedChartHeight - dataArea.getHeight() + plotHeight;
+
+        if ((int) lastW == (int) estimatedChartWidth && (int) lastH == (int) estimatedChartHeight)
+          break;
+        else {
+          lastW = estimatedChartWidth;
+          lastH = estimatedChartHeight;
+        }
+      }
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
+
+    return new Dimension((int) estimatedChartWidth, (int) estimatedChartHeight);
+  }
+
+  /**
+   * calls this method twice (2 iterations) with an estimated chartHeight of 3*chartWidth Domain and
+   * Range axes need to share the same unit (e.g. mm)
+   * 
+   * @param myChart
+   * @param dataWidth width of data
+   * @param axis for width calculation
+   * @return
+   */
+  public static double calcHeightToWidth(ChartViewer myChart, double chartWidth) {
+    return calcHeightToWidth(myChart, chartWidth, chartWidth * 3, 4);
+  }
+
+  /**
+   * calculates the correct height with multiple iterations Domain and Range axes need to share the
+   * same unit (e.g. mm)
+   * 
+   * @param myChart
+   * @param dataWidth width of data
+   * @param axis for width calculation
+   * @return
+   */
+  public static double calcHeightToWidth(ChartViewer myChart, double chartWidth,
+      double estimatedHeight, int iterations) {
+    // if(myChart.getChartRenderingInfo()==null ||
+    // myChart.getChartRenderingInfo().getChartArea()==null ||
+    // myChart.getChartRenderingInfo().getChartArea().getWidth()==0)
+    // result
+    double height = estimatedHeight;
+    double lastH = height;
+
+    makeChartResizable(myChart);
+
+    try {
+      for (int i = 0; i < iterations; i++) {
+        // paint on ghost panel with estimated height (if copy panel==true)
+        myChart.getCanvas().setWidth((int) chartWidth);
+        myChart.getCanvas().setHeight((int) estimatedHeight);
+        myChart.getCanvas().draw();
+
+        XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+        ChartRenderingInfo info = myChart.getRenderingInfo();
+        Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+        Rectangle2D chartArea = info.getChartArea();
+
+        // calc title space: will be added later to the right plot size
+        double titleWidth = chartArea.getWidth() - dataArea.getWidth();
+        double titleHeight = chartArea.getHeight() - dataArea.getHeight();
+
+        // calc right plot size with axis dim.
+        // real plot width is given by factor;
+        double realPW = chartWidth - titleWidth;
+
+        // ranges
+        ValueAxis domainAxis = plot.getDomainAxis();
+        org.jfree.data.Range x = domainAxis.getRange();
+        ValueAxis rangeAxis = plot.getRangeAxis();
+        org.jfree.data.Range y = rangeAxis.getRange();
+
+        // real plot height can be calculated by
+        double realPH = realPW / x.getLength() * y.getLength();
+
+        // the real height
+        height = realPH + titleHeight;
+
+        // for next iteration
+        estimatedHeight = height;
+        if ((int) lastH == (int) height)
+          break;
+        else
+          lastH = height;
+      }
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
+
+    return height;
+  }
+
+  /**
+   * Removes draw size restrictions
+   * 
+   * @param myChart
+   */
+  public static void makeChartResizable(ChartViewer myChart) {
+    // TODO set max and min sizes
+  }
+
+  /**
+   * 
+   * Domain and Range axes need to share the same unit (e.g. mm)
+   * 
+   * @param myChart
+   * @return
+   */
+  public static double calcWidthToHeight(ChartViewer myChart, double chartHeight) {
+    makeChartResizable(myChart);
+
+    myChart.getCanvas().draw();
+
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ChartRenderingInfo info = myChart.getRenderingInfo();
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+    Rectangle2D chartArea = info.getChartArea();
+
+
+    // calc title space: will be added later to the right plot size
+    double titleWidth = chartArea.getWidth() - dataArea.getWidth();
+    double titleHeight = chartArea.getHeight() - dataArea.getHeight();
+
+    // calc right plot size with axis dim.
+    // real plot width is given by factor;
+    double realPH = chartHeight - titleHeight;
+
+    // ranges
+    ValueAxis domainAxis = plot.getDomainAxis();
+    org.jfree.data.Range x = domainAxis.getRange();
+    ValueAxis rangeAxis = plot.getRangeAxis();
+    org.jfree.data.Range y = rangeAxis.getRange();
+
+    // real plot height can be calculated by
+    double realPW = realPH / y.getLength() * x.getLength();
+
+    double width = realPW + titleWidth;
+
+    return width;
+  }
+
+  /**
+   * Returns dimensions for limiting factor width or height
+   * 
+   * @param myChart
+   * @return
+   */
+  public static Dimension calcMaxSize(ChartViewer myChart, double chartWidth, double chartHeight) {
+    makeChartResizable(myChart);
+    // paint on a ghost panel
+    myChart.getCanvas().draw();
+
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ChartRenderingInfo info = myChart.getRenderingInfo();
+    Rectangle2D dataArea = info.getPlotInfo().getDataArea();
+    Rectangle2D chartArea = info.getChartArea();
+
+
+    // calc title space: will be added later to the right plot size
+    double titleWidth = chartArea.getWidth() - dataArea.getWidth();
+    double titleHeight = chartArea.getHeight() - dataArea.getHeight();
+
+    // calculatig width for max height
+
+    // calc right plot size with axis dim.
+    // real plot width is given by factor;
+    double realPH = chartHeight - titleHeight;
+
+    // ranges
+    ValueAxis domainAxis = plot.getDomainAxis();
+    org.jfree.data.Range x = domainAxis.getRange();
+    ValueAxis rangeAxis = plot.getRangeAxis();
+    org.jfree.data.Range y = rangeAxis.getRange();
+
+    // real plot height can be calculated by
+    double realPW = realPH / y.getLength() * x.getLength();
+
+    double width = realPW + titleWidth;
+    // if width is higher than given chartWidth then calc height for chartWidth
+    if (width > chartWidth) {
+      // calc right plot size with axis dim.
+      // real plot width is given by factor;
+      realPW = chartWidth - titleWidth;
+
+      // real plot height can be calculated by
+      realPH = realPW / x.getLength() * y.getLength();
+
+      double height = realPH + titleHeight;
+      // Return size
+      return new Dimension((int) chartWidth, (int) height);
+    } else {
+      // Return size
+      return new Dimension((int) width, (int) chartHeight);
+    }
+  }
+
+
+
+  /**
+   * 
+   * @param myChart
+   * @return Range the domainAxis zoom (X-axis)
+   */
+  public static Range getZoomDomainAxis(ChartViewer myChart) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+
+    return new Range(domainAxis.getLowerBound(), domainAxis.getUpperBound());
+  }
+
+  /**
+   * Zoom into a chart panel
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void setZoomDomainAxis(ChartViewer myChart, Range zoom, boolean autoRangeY) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    setZoomAxis(domainAxis, keepRangeWithinAutoBounds(domainAxis, zoom));
+
+    if (autoRangeY) {
+      autoRangeAxis(myChart);
+    }
+  }
+
+  /**
+   * Zoom into a chart panel
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void setZoomAxis(ValueAxis axis, Range zoom) {
+    axis.setRange(zoom);
+  }
+
+
+  /**
+   * Auto range the range axis
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void autoAxes(ChartViewer myChart) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    if (plot instanceof Zoomable) {
+      Zoomable z = plot;
+      Point2D endPoint = new Point2D.Double(0, 0);
+      PlotRenderingInfo pri = myChart.getRenderingInfo().getPlotInfo();
+      boolean saved = plot.isNotify();
+      plot.setNotify(false);
+      z.zoomDomainAxes(0, pri, endPoint);
+      z.zoomRangeAxes(0, pri, endPoint);
+      plot.setNotify(saved);
+    }
+  }
+
+  /**
+   * Auto range the range axis
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void autoRangeAxis(ChartViewer myChart) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    if (plot instanceof Zoomable) {
+      Zoomable z = plot;
+      Point2D endPoint = new Point2D.Double(0, 0);
+      PlotRenderingInfo pri = myChart.getRenderingInfo().getPlotInfo();
+      z.zoomRangeAxes(0, pri, endPoint);
+    }
+  }
+
+  /**
+   * Auto range the range axis
+   * 
+   * @param myChart
+   * @param zoom
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void autoDomainAxis(ChartViewer myChart) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    if (plot instanceof Zoomable) {
+      Zoomable z = plot;
+      Point2D endPoint = new Point2D.Double(0, 0);
+      PlotRenderingInfo pri = myChart.getRenderingInfo().getPlotInfo();
+      z.zoomDomainAxes(0, pri, endPoint);
+    }
+  }
+
+  /**
+   * Auto range the axis
+   * 
+   * @param axis
+   */
+  public static void autoAxis(ValueAxis axis) {
+    axis.resizeRange(0);
+  }
+
+  /**
+   * Move a chart by a percentage x-offset if xoffset is <0 the shift will be negativ (xoffset>0
+   * results in a positive shift)
+   * 
+   * @param myChart
+   * @param xoffset in percent
+   * @param autoRangeY if true the range (Y) axis auto bounds will be restored
+   */
+  public static void offsetDomainAxis(ChartViewer myChart, double xoffset, boolean autoRangeY) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    // apply offset on x
+    double distance = (domainAxis.getUpperBound() - domainAxis.getLowerBound()) * xoffset;
+
+    Range range =
+        new Range(domainAxis.getLowerBound() + distance, domainAxis.getUpperBound() + distance);
+    setZoomDomainAxis(myChart, keepRangeWithinAutoBounds(domainAxis, range), autoRangeY);
+  }
+
+  /**
+   * Apply an absolute offset to domain (x) axis and move it
+   * 
+   * @param myChart
+   * @param xoffset
+   * @param autoRangeY
+   */
+  public static void offsetDomainAxisAbsolute(ChartViewer myChart, double xoffset,
+      boolean autoRangeY) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis domainAxis = plot.getDomainAxis();
+    // apply offset on x
+
+    Range range =
+        new Range(domainAxis.getLowerBound() + xoffset, domainAxis.getUpperBound() + xoffset);
+    setZoomDomainAxis(myChart, keepRangeWithinAutoBounds(domainAxis, range), autoRangeY);
+  }
+
+  /**
+   * Apply an absolute offset to an axis and move it
+   * 
+   * @param myChart
+   * @param offset
+   */
+  public static void offsetAxisAbsolute(ValueAxis axis, double offset) {
+    Range range = new Range(axis.getLowerBound() + offset, axis.getUpperBound() + offset);
+    setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+  }
+
+  /**
+   * Apply an relative offset to an axis and move it. LowerBound and UpperBound are defined by
+   * {@link ValueAxis#getDefaultAutoRange()}
+   * 
+   * @param myChart
+   * @param offset percentage
+   */
+  public static void offsetAxis(ValueAxis axis, double offset) {
+    double distance = (axis.getUpperBound() - axis.getLowerBound()) * offset;
+    Range range = new Range(axis.getLowerBound() + distance, axis.getUpperBound() + distance);
+    setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+  }
+
+  public static Range keepRangeWithinAutoBounds(ValueAxis axis, Range range) {
+    // keep within auto range bounds
+    // Range auto = axis.getDefaultAutoRange();
+    // if(range.getLowerBound()<auto.getLowerBound()){
+    // double negative = range.getLowerBound()-auto.getLowerBound();
+    // range = new Range(auto.getLowerBound(), range.getUpperBound()-negative);
+    // }
+    // if(range.getUpperBound()>auto.getUpperBound()) {
+    // double positive = range.getUpperBound()-auto.getUpperBound();
+    // range = new Range(range.getLowerBound()-positive, auto.getUpperBound());
+    // }
+    return range;
+  }
+
+  /**
+   * Zoom in (negative yzoom) or zoom out of range axis.
+   * 
+   * @param myChart
+   * @param yzoom percentage zoom factor
+   * @param holdLowerBound if true only the upper bound will be zoomed
+   */
+  public static void zoomRangeAxis(ChartViewer myChart, double yzoom, boolean holdLowerBound) {
+    XYPlot plot = (XYPlot) myChart.getChart().getPlot();
+    ValueAxis rangeAxis = plot.getRangeAxis();
+
+    double lower = rangeAxis.getLowerBound();
+    double upper = rangeAxis.getUpperBound();
+    double dist = upper - lower;
+
+    if (holdLowerBound) {
+      upper += dist * yzoom;
+    } else {
+      lower -= dist * yzoom / 2;
+      upper += dist * yzoom / 2;
+    }
+
+    if (lower < upper) {
+      Range range = new Range(lower, upper);
+      setZoomAxis(rangeAxis, keepRangeWithinAutoBounds(rangeAxis, range));
+    }
+  }
+
+  /**
+   * Zoom in (negative zoom) or zoom out of axis.
+   * 
+   * @param myChart
+   * @param zoom percentage zoom factor
+   * @param holdLowerBound if true only the upper bound will be zoomed
+   */
+  public static void zoomAxis(ValueAxis axis, double zoom, boolean holdLowerBound) {
+    double lower = axis.getLowerBound();
+    double upper = axis.getUpperBound();
+    double dist = upper - lower;
+
+    if (holdLowerBound) {
+      if (zoom == 0)
+        return;
+      upper += dist * zoom;
+    } else {
+      lower -= dist * zoom / 2;
+      upper += dist * zoom / 2;
+    }
+
+    if (lower < upper) {
+      logger.info("Set zoom:" + lower + ", " + upper + " (keep lower:" + holdLowerBound + ")");
+      Range range = new Range(lower, upper);
+      setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+    }
+  }
+
+  /**
+   * Zoom in (negative zoom) or zoom out of axis.
+   * 
+   * @param myChart
+   * @param zoom percentage zoom factor
+   * @param start point on this range (first click/pressed event), used as center
+   */
+  public static void zoomAxis(ValueAxis axis, double zoom, double start) {
+    double lower = axis.getLowerBound();
+    double upper = axis.getUpperBound();
+    double dist = upper - lower;
+    double f = (start - lower) / dist;
+
+    lower -= dist * zoom * f;
+    upper += dist * zoom * (1 - f);
+
+    if (lower < upper) {
+      Range range = new Range(lower, upper);
+      setZoomAxis(axis, keepRangeWithinAutoBounds(axis, range));
+    }
+  }
+
+  /**
+   * 
+   * @param ChartViewer
+   * @return
+   */
+  // TODO
+  public static boolean isMouseZoomable(ChartViewer chart) {
+    // return chartPanel instanceof EChartPanel ? ((EChartPanel) chartPanel).isMouseZoomable()
+    // : chartPanel.isRangeZoomable() && chartPanel.isDomainZoomable();
+    return chart.getCanvas().isRangeZoomable() && chart.getCanvas().isDomainZoomable();
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/HistogramChartFactory.java
+++ b/src/main/java/io/github/mzmine/chartbasics/HistogramChartFactory.java
@@ -1,0 +1,650 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+
+package net.sf.mzmine.chartbasics;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Paint;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.DoubleFunction;
+import org.apache.commons.math3.analysis.function.Gaussian;
+import org.apache.commons.math3.fitting.GaussianCurveFitter;
+import org.apache.commons.math3.fitting.WeightedObservedPoints;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.ValueMarker;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.StandardXYBarPainter;
+import org.jfree.chart.renderer.xy.XYBarRenderer;
+import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
+import org.jfree.data.Range;
+import org.jfree.data.statistics.HistogramDataset;
+import org.jfree.data.xy.XYBarDataset;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import net.sf.mzmine.datamodel.DataPoint;
+import net.sf.mzmine.datamodel.impl.SimpleDataPoint;
+import net.sf.mzmine.util.maths.Precision;
+
+public class HistogramChartFactory {
+  private static final Logger logger = LoggerFactory.getLogger(HistogramChartFactory.class);
+
+  private static GaussianCurveFitter fitter = GaussianCurveFitter.create().withMaxIterations(10000);
+
+  /**
+   * Performs Gaussian fit on XYSeries
+   * 
+   * @param data the data
+   * @param gMin lower bound of Gaussian fit
+   * @param gMax upper bound of Gaussian fit
+   * @param sigDigits number of significant digits
+   * @return double[] {normFactor, mean, sigma} as a result of
+   *         GaussianCurveFitter.create().fit(obs.toList())
+   */
+  public static double[] gaussianFit(List<DataPoint> data, double gMin, double gMax) {
+    // gaussian fit
+    WeightedObservedPoints obs = new WeightedObservedPoints();
+
+    for (int i = 0; i < data.size(); i++) {
+      double x = data.get(i).getMZ();
+      if (x >= gMin && x <= gMax)
+        obs.add(x, data.get(i).getIntensity());
+    }
+    try {
+      return fitter.fit(obs.toList());
+    } catch (Exception e) {
+      e.printStackTrace();
+      logger.error("Cannot fit Gaussian from {} to {}", gMin, gMax, e);
+      return null;
+    }
+  }
+
+  /**
+   * Performs Gaussian fit on XYSeries
+   * 
+   * @param series the data
+   * @param gMin lower bound of Gaussian fit
+   * @param gMax upper bound of Gaussian fit
+   * @param sigDigits number of significant digits
+   * @return double[] {normFactor, mean, sigma} as a result of
+   *         GaussianCurveFitter.create().fit(obs.toList())
+   */
+  public static double[] gaussianFit(XYSeries series, double gMin, double gMax) {
+    // gaussian fit
+    WeightedObservedPoints obs = new WeightedObservedPoints();
+
+    for (int i = 0; i < series.getItemCount(); i++) {
+      double x = series.getX(i).doubleValue();
+      if (x >= gMin && x <= gMax)
+        obs.add(x, series.getY(i).doubleValue());
+    }
+
+    return fitter.fit(obs.toList());
+  }
+
+  /**
+   * Performs Gaussian fit on XYSeries
+   * 
+   * @param data the data
+   * @param series the series index
+   * @param gMin lower bound of Gaussian fit
+   * @param gMax upper bound of Gaussian fit
+   * @param sigDigits number of significant digits
+   * @return double[] {normFactor, mean, sigma} as a result of
+   *         GaussianCurveFitter.create().fit(obs.toList())
+   */
+  public static double[] gaussianFit(XYDataset data, int series, double gMin, double gMax) {
+    // gaussian fit
+    WeightedObservedPoints obs = new WeightedObservedPoints();
+
+    for (int i = 0; i < data.getItemCount(series); i++) {
+      double x = data.getXValue(series, i);
+      if (x >= gMin && x <= gMax)
+        obs.add(x, data.getYValue(series, i));
+    }
+    return fitter.fit(obs.toList());
+  }
+
+  /**
+   * Adds a Gaussian curve to the plot
+   * 
+   * @param plot
+   * @param series the data
+   * @param gMin lower bound of Gaussian fit
+   * @param gMax upper bound of Gaussian fit
+   * @param sigDigits number of significant digits
+   * @return
+   */
+  public static double[] addGaussianFit(XYPlot plot, XYSeries series, double gMin, double gMax,
+      int sigDigits, boolean annotations) {
+    double[] fit = gaussianFit(series, gMin, gMax);
+    double minval = series.getX(0).doubleValue();
+    double maxval = series.getX(series.getItemCount() - 1).doubleValue();
+    return addGaussianFit(plot, fit, minval, maxval, gMin, gMax, sigDigits, annotations);
+  }
+
+  /**
+   * Adds a Gaussian curve to the plot
+   * 
+   * @param plot
+   * @param data the data
+   * @param series the series index
+   * @param gMin lower bound of Gaussian fit
+   * @param gMax upper bound of Gaussian fit
+   * @param sigDigits number of significant digits
+   * @return
+   */
+  public static double[] addGaussianFit(XYPlot plot, XYDataset data, int series, double gMin,
+      double gMax, int sigDigits, boolean annotations) {
+    double[] fit = gaussianFit(data, series, gMin, gMax);
+    double minval = data.getX(series, 0).doubleValue();
+    double maxval = data.getX(series, data.getItemCount(series) - 1).doubleValue();
+    return addGaussianFit(plot, fit, minval, maxval, gMin, gMax, sigDigits, annotations);
+  }
+
+  /**
+   * Adds a Gaussian curve to the plot
+   * 
+   * @param plot
+   * @param fit double[] {normFactor, mean, sigma}
+   * @param drawStart start of curve
+   * @param drawEnd end of curve
+   * @param sigDigits number of significant digits
+   * @return
+   */
+  public static double[] addGaussianFit(XYPlot plot, double[] fit, double drawStart, double drawEnd,
+      int sigDigits, boolean annotations) {
+    return addGaussianFit(plot, fit, drawStart, drawEnd, drawStart, drawEnd, sigDigits,
+        annotations);
+  }
+
+  /**
+   * Adds a Gaussian curve to the plot
+   * 
+   * @param plot
+   * @param fit double[] {normFactor, mean, sigma}
+   * @param drawStart start of curve
+   * @param drawEnd end of curve
+   * @param gMin lower bound of Gaussian fit
+   * @param gMax upper bound of Gaussian fit
+   * @param sigDigits number of significant digits
+   * @return
+   */
+  public static double[] addGaussianFit(XYPlot plot, double[] fit, double drawStart, double drawEnd,
+      double gMin, double gMax, int sigDigits, boolean annotations) {
+    double gWidth = gMax - gMin;
+
+    Gaussian g = new Gaussian(fit[0], fit[1], fit[2]);
+
+    // create xy series for gaussian
+    String mean = Precision.toString(fit[1], sigDigits, 7);
+    String sigma = Precision.toString(fit[2], sigDigits, 7);
+    String norm = Precision.toString(fit[0], sigDigits, 7);
+    XYSeries gs = new XYSeries("Gaussian: " + mean + " \u00B1 " + sigma + " [" + norm
+        + "] (mean \u00B1 sigma [normalisation])");
+    // add lower dp number out of gaussian fit range
+    int steps = 100;
+    if (gMin > drawStart) {
+      for (int i = 0; i <= steps; i++) {
+        double x = drawStart + ((gMin - drawStart) / steps) * i;
+        double y = g.value(x);
+        gs.add(x, y);
+      }
+    }
+    // add high resolution in gaussian fit area
+    steps = 1000;
+    for (int i = 0; i <= steps; i++) {
+      double x = gMin + (gWidth / steps) * i;
+      double y = g.value(x);
+      gs.add(x, y);
+    }
+    // add lower dp number out of gaussian fit range
+    steps = 100;
+    if (gMax < drawEnd) {
+      for (int i = 0; i <= steps; i++) {
+        double x = gMax + ((drawEnd - gMax) / steps) * i;
+        double y = g.value(x);
+        gs.add(x, y);
+      }
+    }
+    // add gaussian
+    XYSeriesCollection gsdata = new XYSeriesCollection(gs);
+    int index = plot.getDatasetCount();
+    plot.setDataset(index, gsdata);
+    plot.setRenderer(index, new XYLineAndShapeRenderer(true, false));
+
+    if (annotations)
+      addGaussianFitAnnotations(plot, fit);
+
+    return fit;
+  }
+
+
+  /**
+   * Adds annotations to the Gaussian fit parameters
+   * 
+   * @param plot
+   * @param fit Gaussian fit {normalisation factor, mean, sigma}
+   */
+  public static void addGaussianFitAnnotations(XYPlot plot, double[] fit) {
+    Paint c = plot.getDomainCrosshairPaint();
+    BasicStroke s = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1,
+        new float[] {5f, 2.5f}, 0);
+
+    plot.addDomainMarker(new ValueMarker(fit[1], c, s));
+    plot.addDomainMarker(new ValueMarker(fit[1] - fit[2], c, s));
+    plot.addDomainMarker(new ValueMarker(fit[1] + fit[2], c, s));
+  }
+
+
+  public static JFreeChart createHistogram(double[] data, double binwidth) {
+    return createHistogram(data, binwidth, null);
+  }
+
+  public static JFreeChart createHistogram(double[] data, double binwidth, String yAxisLabel) {
+    Range r = getBounds(data);
+    return createHistogram(data, binwidth, yAxisLabel, r.getLowerBound(), r.getUpperBound(), null);
+  }
+
+  public static JFreeChart createHistogram(double[] data, double binwidth, String yAxisLabel,
+      double min, double max, DoubleFunction<Double> function) {
+    if (data != null && data.length > 0) {
+      double datawidth = (max - min);
+      int cbin = (int) Math.ceil(datawidth / binwidth);
+      int[] bins = new int[cbin + 1];
+
+      XYSeries series = createHistoSeries(data, binwidth, min, max, function);
+      double barwidth = binwidth;
+
+      // calc new barwidth if a transformation function is defined
+      if (function != null) {
+        int sum = Arrays.stream(bins).sum();
+        // see when 98% of the data is displayed
+        int sum2 = 0;
+        for (int i = 0; i < bins.length; i++) {
+          if (bins[i] > 0) {
+            sum2 += bins[i];
+            if ((sum2 / (double) sum) >= 0.99) {
+              barwidth = function.apply(min + (binwidth / 2.0) + i * binwidth).doubleValue()
+                  - function.apply(min + (binwidth / 2.0) + (i - 1) * binwidth).doubleValue();
+            }
+          }
+        }
+      }
+      return createHistogram(series, barwidth, yAxisLabel);
+    } else
+      return null;
+  }
+
+
+  public static JFreeChart createHistogram(XYSeries series, double barwidth, String yAxisLabel) {
+    XYSeriesCollection xydata = new XYSeriesCollection(series);
+    XYBarDataset dataset = new XYBarDataset(xydata, barwidth);
+    JFreeChart chart = ChartFactory.createXYBarChart("", yAxisLabel, false, "n", dataset,
+        PlotOrientation.VERTICAL, true, true, false);
+
+    XYPlot xyplot = chart.getXYPlot();
+    chart.setBackgroundPaint(new Color(230, 230, 230));
+    chart.getLegend().setVisible(false);
+    xyplot.setForegroundAlpha(0.7F);
+    xyplot.setBackgroundPaint(Color.WHITE);
+    xyplot.setDomainGridlinePaint(new Color(150, 150, 150));
+    xyplot.setRangeGridlinePaint(new Color(150, 150, 150));
+    xyplot.getDomainAxis().setVisible(true);
+    xyplot.getRangeAxis().setVisible(yAxisLabel != null);
+    XYBarRenderer xybarrenderer = (XYBarRenderer) xyplot.getRenderer();
+    xybarrenderer.setShadowVisible(false);
+    xybarrenderer.setBarPainter(new StandardXYBarPainter());
+    xybarrenderer.setDrawBarOutline(false);
+    return chart;
+  }
+
+
+  /**
+   * Converts from double array to histogram array
+   * 
+   * @param data
+   * @param binwidth
+   * @return A histogram array with length = datawidth/binwidth +1 (datawidth = max-min)
+   */
+  public static XYSeries createHistoSeries(double[] data, double binwidth) {
+    Range r = getBounds(data);
+    return createHistoSeries(data, binwidth, r.getLowerBound(), r.getUpperBound(), null);
+  }
+
+  /**
+   * Converts from double array to histogram array
+   * 
+   * @param data
+   * @param binwidth
+   * @param min real minimum of data
+   * @param max real maximum of data
+   * @param function function to transform data axis
+   * @return A histogram array with length = datawidth/binwidth +1 (datawidth = max-min)
+   */
+  public static XYSeries createHistoSeries(double[] data, double binwidth, double min, double max,
+      DoubleFunction<Double> function) {
+    double datawidth = (max - min);
+    int cbin = (int) Math.ceil(datawidth / binwidth);
+    int[] bins = new int[cbin + 1];
+
+    // count intensities in bins
+    // if value>bin.upper put in next
+    for (double v : data) {
+      int i = (int) Math.ceil((v - min) / binwidth) - 1;
+      if (i < 0) // does only happen if min>than minimum value of data
+        i = 0;
+      if (i >= bins.length)
+        i = bins.length - 1;
+      bins[i]++;
+    }
+
+    // add zeros around data
+    boolean peakStarted = false;
+    XYSeries series = new XYSeries("histo", true, true);
+    for (int i = 0; i < bins.length; i++) {
+      // start peak and add data if>0
+      if (bins[i] > 0) {
+        // add previous zero once
+        if (!peakStarted && i > 0)
+          addDPToSeries(series, bins, i - 1, binwidth, min, max, function);
+
+        // add data
+        addDPToSeries(series, bins, i, binwidth, min, max, function);
+
+        peakStarted = true;
+      } else {
+        // add trailing zero
+        addDPToSeries(series, bins, i, binwidth, min, max, function);
+        peakStarted = false;
+      }
+    }
+    return series;
+  }
+
+  /**
+   * Converts from double array to histogram array
+   * 
+   * @param data
+   * @param binwidth
+   * @param min real minimum of data
+   * @param max real maximum of data
+   * @param function function to transform data axis
+   * @return A histogram array with length = datawidth/binwidth +1 (datawidth = max-min)
+   */
+  public static XYSeries createHistoSeries(DoubleArrayList data, double binwidth, double min,
+      double max, DoubleFunction<Double> function) {
+    double datawidth = (max - min);
+    int cbin = (int) Math.ceil(datawidth / binwidth);
+    int[] bins = new int[cbin + 1];
+
+    // count intensities in bins
+    // if value>bin.upper put in next
+    for (double v : data) {
+      int i = (int) Math.ceil((v - min) / binwidth) - 1;
+      if (i < 0) // does only happen if min>than minimum value of data
+        i = 0;
+      if (i >= bins.length)
+        i = bins.length - 1;
+      bins[i]++;
+    }
+
+    // add zeros around data
+    boolean peakStarted = false;
+    XYSeries series = new XYSeries("histo", true, true);
+    for (int i = 0; i < bins.length; i++) {
+      // start peak and add data if>0
+      if (bins[i] > 0) {
+        // add previous zero once
+        if (!peakStarted && i > 0)
+          addDPToSeries(series, bins, i - 1, binwidth, min, max, function);
+
+        // add data
+        addDPToSeries(series, bins, i, binwidth, min, max, function);
+
+        peakStarted = true;
+      } else {
+        // add trailing zero
+        addDPToSeries(series, bins, i, binwidth, min, max, function);
+        peakStarted = false;
+      }
+    }
+    return series;
+  }
+
+  private static void addDPToSeries(XYSeries series, int[] bins, int i, double binwidth, double min,
+      double max, DoubleFunction<Double> function) {
+    // adds a data point to the series
+    double x = min + (binwidth / 2.0) + i * binwidth;
+    if (function != null)
+      x = function.apply(x);
+    series.add(x, bins[i]);
+  }
+
+  /**
+   * Converts from double array to histogram array
+   * 
+   * @param data
+   * @param binwidth
+   * @param min real minimum of data
+   * @param max real maximum of data
+   * @param function function to transform data axis
+   * @return A histogram array with length = datawidth/binwidth +1 (datawidth = max-min)
+   */
+  public static List<DataPoint> createHistoList(DoubleArrayList data, double binwidth, double min,
+      double max, DoubleFunction<Double> function) {
+    double datawidth = (max - min);
+    int cbin = (int) Math.ceil(datawidth / binwidth);
+    int[] bins = new int[cbin + 1];
+
+    // count intensities in bins
+    // if value>bin.upper put in next
+    for (double v : data) {
+      int i = (int) Math.ceil((v - min) / binwidth) - 1;
+      if (i < 0) // does only happen if min>than minimum value of data
+        i = 0;
+      if (i >= bins.length)
+        i = bins.length - 1;
+      bins[i]++;
+    }
+
+    // add zeros around data
+    List<DataPoint> result = new ArrayList<>();
+    boolean peakStarted = false;
+    for (int i = 0; i < bins.length; i++) {
+      // start peak and add data if>0
+      if (bins[i] > 0) {
+        // add previous zero once
+        if (!peakStarted && i > 0)
+          addDPToList(result, bins, i - 1, binwidth, min, max, function);
+
+        // add data
+        addDPToList(result, bins, i, binwidth, min, max, function);
+
+        peakStarted = true;
+      } else {
+        // add trailing zero
+        addDPToList(result, bins, i, binwidth, min, max, function);
+        peakStarted = false;
+      }
+    }
+    return result;
+  }
+
+  private static void addDPToList(List<DataPoint> list, int[] bins, int i, double binwidth,
+      double min, double max, DoubleFunction<Double> function) {
+    // adds a data point to the series
+    double x = min + (binwidth / 2.0) + i * binwidth;
+    if (function != null)
+      x = function.apply(x);
+    list.add(new SimpleDataPoint(x, bins[i]));
+  }
+
+
+  /**
+   * Adds a value to a Histogram array. bins array should have length = datawidth/binwidth +1
+   * (datawidth = max-min)
+   * 
+   * @param bins
+   * @param value
+   * @param binwidth
+   * @param min minimum of
+   */
+  public static void addValueToHistoArray(int[] bins, double value, double binwidth, double min) {
+    int i = (int) Math.ceil((value - min) / binwidth) - 1;
+    if (i < 0) // does only happen if min>than minimum value of data
+      i = 0;
+    if (i >= bins.length)
+      i = bins.length - 1;
+    bins[i]++;
+  }
+
+
+
+  public static JFreeChart createHistogramOld(double[] data, int bin, String yAxisLabel, double min,
+      double max) {
+    if (data != null && data.length > 0) {
+      HistogramDataset dataset = new HistogramDataset();
+      dataset.addSeries("histo", data, bin, min, max);
+
+      JFreeChart chart = ChartFactory.createHistogram("", yAxisLabel, "n", dataset,
+          PlotOrientation.VERTICAL, true, false, false);
+
+      chart.setBackgroundPaint(new Color(230, 230, 230));
+      chart.getLegend().setVisible(false);
+      XYPlot xyplot = chart.getXYPlot();
+      xyplot.setForegroundAlpha(0.7F);
+      xyplot.setBackgroundPaint(Color.WHITE);
+      xyplot.setDomainGridlinePaint(new Color(150, 150, 150));
+      xyplot.setRangeGridlinePaint(new Color(150, 150, 150));
+      xyplot.getDomainAxis().setVisible(true);
+      xyplot.getRangeAxis().setVisible(yAxisLabel != null);
+      XYBarRenderer xybarrenderer = (XYBarRenderer) xyplot.getRenderer();
+      xybarrenderer.setShadowVisible(false);
+      xybarrenderer.setBarPainter(new StandardXYBarPainter());
+      // xybarrenderer.setDrawBarOutline(false);
+      return chart;
+    } else
+      return null;
+  }
+
+  public static JFreeChart createHistogram(double[] data) {
+    double bin = Math.sqrt(data.length);
+    Range r = getBounds(data);
+    return createHistogram(data, r.getLength() / bin);
+  }
+
+  public static JFreeChart createHistogram(double[] data, String yAxisLabel) {
+    Range range = getBounds(data);
+    return createHistogram(data, yAxisLabel, range.getLowerBound(), range.getUpperBound());
+  }
+
+  public static JFreeChart createHistogram(double[] data, String yAxisLabel, double min,
+      double max) {
+    return createHistogram(data, yAxisLabel, min, max, val -> val);
+  }
+
+  public static JFreeChart createHistogram(double[] data, String yAxisLabel, double min, double max,
+      DoubleFunction<Double> function) {
+    int bin = (int) Math.sqrt(data.length);
+    Range r = getBounds(data);
+    return createHistogram(data, r.getLength() / bin, yAxisLabel, min, max, function);
+  }
+
+  /**
+   * 
+   * @param data
+   * @param yAxisLabel
+   * @param width automatic width if parameter is <=0
+   * @return
+   */
+  public static JFreeChart createHistogram(double[] data, String yAxisLabel, double width) {
+    Range range = getBounds(data);
+    return createHistogram(data, yAxisLabel, width, range.getLowerBound(), range.getUpperBound());
+  }
+
+  /**
+   * 
+   * @param data
+   * @param yAxisLabel
+   * @param width automatic width if parameter is <=0
+   * @return
+   */
+  public static JFreeChart createHistogram(double[] data, String yAxisLabel, double width,
+      double min, double max) {
+    if (width <= 0)
+      return createHistogram(data, yAxisLabel, min, max);
+    else {
+      return createHistogram(data, width, yAxisLabel, min, max, val -> val);
+    }
+  }
+
+  /**
+   * 
+   * @param data
+   * @param yAxisLabel
+   * @param width automatic width if parameter is <=0
+   * @param function transform the data axis after binning
+   * @return
+   */
+  public static JFreeChart createHistogram(double[] data, String yAxisLabel, double width,
+      double min, double max, DoubleFunction<Double> function) {
+    if (width <= 0)
+      return createHistogram(data, yAxisLabel, min, max, function);
+    else {
+      return createHistogram(data, width, yAxisLabel, min, max, function);
+    }
+  }
+
+  public static double getMin(double[] data) {
+    double min = Double.MAX_VALUE;
+    for (double d : data)
+      if (d < min)
+        min = d;
+    return min;
+  }
+
+  public static double getMax(double[] data) {
+    double max = Double.NEGATIVE_INFINITY;
+    for (double d : data)
+      if (d > max)
+        max = d;
+    return max;
+  }
+
+  public static Range getBounds(double[] data) {
+    double min = Double.MAX_VALUE;
+    double max = Double.NEGATIVE_INFINITY;
+    for (double d : data) {
+      if (d < min)
+        min = d;
+      if (d > max)
+        max = d;
+    }
+    return new Range(min, max);
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/chartthemes/ChartThemeFactory.java
+++ b/src/main/java/io/github/mzmine/chartbasics/chartthemes/ChartThemeFactory.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.chartthemes;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Paint;
+import java.awt.Stroke;
+import org.jfree.chart.ChartColor;
+import org.jfree.chart.plot.DefaultDrawingSupplier;
+import org.jfree.chart.ui.RectangleInsets;
+
+/**
+ * Creates {@link EStandardChartTheme}s
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartThemeFactory {
+
+  public enum THEME {
+    // main themes
+    BNW_PRINT, KARST, DARKNESS,
+    // separate options
+    FOR_PRINT, FOR_PRESENTATION;
+
+    public static THEME getTheme(String ident) {
+      // integer?
+      try {
+        int i = Integer.parseInt(ident);
+        switch (i) {
+          case 0:
+            return BNW_PRINT;
+          case 1:
+            return KARST;
+          case 2:
+            return DARKNESS;
+          case 50:
+            return FOR_PRINT;
+          case 51:
+            return FOR_PRESENTATION;
+        }
+      } catch (Exception ex) {
+      }
+      // else value of
+      return valueOf(ident);
+    }
+
+  }
+
+  // the standard to be applied to all new charts
+  protected static THEME standardTheme = THEME.BNW_PRINT;
+
+  public static EStandardChartTheme createChartTheme(THEME theme) {
+    switch (theme) {
+      case BNW_PRINT:
+        return createBlackNWhiteTheme();
+      case DARKNESS:
+        return createDarknessTheme();
+      case KARST:
+        return createKarstTheme();
+    }
+    return createBlackNWhiteTheme();
+  }
+
+  public static EStandardChartTheme changeChartThemeForPrintOrPresentation(
+      EStandardChartTheme theme, boolean forPrint) {
+    if (forPrint) {
+      // Fonts
+      theme.setExtraLargeFont(new Font("Arial", Font.BOLD, 16));
+      theme.setLargeFont(new Font("Arial", Font.BOLD, 11));
+      theme.setRegularFont(new Font("Arial", Font.PLAIN, 11));
+      theme.setSmallFont(new Font("Arial", Font.PLAIN, 11));
+    } else { // for presentation larger fonts
+      // Fonts
+      theme.setExtraLargeFont(new Font("Arial", Font.BOLD, 30));
+      theme.setLargeFont(new Font("Arial", Font.BOLD, 20));
+      theme.setRegularFont(new Font("Arial", Font.PLAIN, 16));
+      theme.setSmallFont(new Font("Arial", Font.PLAIN, 16));
+    }
+    return theme;
+  }
+
+  public static EStandardChartTheme createBlackNWhiteTheme() {
+    EStandardChartTheme theme = new EStandardChartTheme(THEME.BNW_PRINT, "BnW");
+    // Fonts
+    theme.setExtraLargeFont(new Font("Arial", Font.BOLD, 16));
+    theme.setLargeFont(new Font("Arial", Font.BOLD, 11));
+    theme.setRegularFont(new Font("Arial", Font.PLAIN, 11));
+    theme.setSmallFont(new Font("Arial", Font.PLAIN, 11));
+
+    // Paints
+    theme.setTitlePaint(Color.black);
+    theme.setSubtitlePaint(Color.black);
+    theme.setLegendItemPaint(Color.black);
+    theme.setPlotOutlinePaint(Color.black);
+    theme.setBaselinePaint(Color.black);
+    theme.setCrosshairPaint(Color.black);
+    theme.setLabelLinkPaint(Color.black);
+    theme.setTickLabelPaint(Color.black);
+    theme.setAxisLabelPaint(Color.black);
+    theme.setShadowPaint(Color.black);
+    theme.setItemLabelPaint(Color.black);
+
+    theme.setLegendBackgroundPaint(Color.white);
+    theme.setChartBackgroundPaint(Color.white);
+    theme.setPlotBackgroundPaint(Color.white);
+
+    // paint sequence: add black
+    Paint[] colors = new Paint[] {Color.BLACK, new Color(0xFF, 0x55, 0x55),
+        new Color(0x55, 0x55, 0xFF), new Color(0x55, 0xFF, 0x55), new Color(0xFF, 0xFF, 0x55),
+        new Color(0xFF, 0x55, 0xFF), new Color(0x55, 0xFF, 0xFF), Color.pink, Color.gray,
+        ChartColor.DARK_RED, ChartColor.DARK_BLUE, ChartColor.DARK_GREEN, ChartColor.DARK_YELLOW,
+        ChartColor.DARK_MAGENTA, ChartColor.DARK_CYAN, Color.darkGray, ChartColor.LIGHT_RED,
+        ChartColor.LIGHT_BLUE, ChartColor.LIGHT_GREEN, ChartColor.LIGHT_YELLOW,
+        ChartColor.LIGHT_MAGENTA, ChartColor.LIGHT_CYAN, Color.lightGray, ChartColor.VERY_DARK_RED,
+        ChartColor.VERY_DARK_BLUE, ChartColor.VERY_DARK_GREEN, ChartColor.VERY_DARK_YELLOW,
+        ChartColor.VERY_DARK_MAGENTA, ChartColor.VERY_DARK_CYAN, ChartColor.VERY_LIGHT_RED,
+        ChartColor.VERY_LIGHT_BLUE, ChartColor.VERY_LIGHT_GREEN, ChartColor.VERY_LIGHT_YELLOW,
+        ChartColor.VERY_LIGHT_MAGENTA, ChartColor.VERY_LIGHT_CYAN};
+
+    theme.setDrawingSupplier(
+        new DefaultDrawingSupplier(colors, DefaultDrawingSupplier.DEFAULT_FILL_PAINT_SEQUENCE,
+            DefaultDrawingSupplier.DEFAULT_OUTLINE_PAINT_SEQUENCE,
+            DefaultDrawingSupplier.DEFAULT_STROKE_SEQUENCE,
+            DefaultDrawingSupplier.DEFAULT_OUTLINE_STROKE_SEQUENCE,
+            DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE));
+    theme.setErrorIndicatorPaint(Color.black);
+    theme.setGridBandPaint(new Color(255, 255, 255, 20));
+    theme.setGridBandAlternatePaint(new Color(255, 255, 255, 40));
+
+    // axis
+    Color transp = new Color(0, 0, 0, 200);
+    theme.setRangeGridlinePaint(transp);
+    theme.setDomainGridlinePaint(transp);
+
+    theme.setAxisLinePaint(Color.black);
+
+    // axis offset
+    theme.setAxisOffset(new RectangleInsets(0, 0, 0, 0));
+
+    return theme;
+  }
+
+
+  /**
+   * Creates and returns a theme called "Darkness". In this theme, the charts have a black
+   * background and white lines and labels
+   *
+   * @return The "Darkness" theme.
+   */
+  public static EStandardChartTheme createDarknessTheme() {
+    EStandardChartTheme theme = new EStandardChartTheme(THEME.DARKNESS, "Darkness");
+    // Fonts
+    theme.setExtraLargeFont(new Font("Arial", Font.BOLD, 20));
+    theme.setLargeFont(new Font("Arial", Font.BOLD, 11));
+    theme.setRegularFont(new Font("Arial", Font.PLAIN, 11));
+    theme.setSmallFont(new Font("Arial", Font.PLAIN, 11));
+    //
+    theme.setTitlePaint(Color.white);
+    theme.setSubtitlePaint(Color.white);
+    theme.setLegendBackgroundPaint(Color.black);
+    theme.setLegendItemPaint(Color.white);
+    theme.setChartBackgroundPaint(Color.black);
+    theme.setPlotBackgroundPaint(Color.black);
+    theme.setPlotOutlinePaint(Color.yellow);
+    theme.setBaselinePaint(Color.white);
+    theme.setCrosshairPaint(Color.red);
+    theme.setLabelLinkPaint(Color.lightGray);
+    theme.setTickLabelPaint(Color.white);
+    theme.setAxisLabelPaint(Color.white);
+    theme.setShadowPaint(Color.darkGray);
+    theme.setItemLabelPaint(Color.white);
+    theme.setDrawingSupplier(new DefaultDrawingSupplier(
+        new Paint[] {Color.WHITE, Color.decode("0xFFFF00"), Color.decode("0x0036CC"),
+            Color.decode("0xFF0000"), Color.decode("0xFFFF7F"), Color.decode("0x6681CC"),
+            Color.decode("0xFF7F7F"), Color.decode("0xFFFFBF"), Color.decode("0x99A6CC"),
+            Color.decode("0xFFBFBF"), Color.decode("0xA9A938"), Color.decode("0x2D4587")},
+        new Paint[] {Color.decode("0xFFFF00"), Color.decode("0x0036CC")},
+        new Stroke[] {new BasicStroke(2.0f)}, new Stroke[] {new BasicStroke(0.5f)},
+        DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE));
+    theme.setErrorIndicatorPaint(Color.lightGray);
+    theme.setGridBandPaint(new Color(255, 255, 255, 20));
+    theme.setGridBandAlternatePaint(new Color(255, 255, 255, 40));
+
+    // axis
+    Color transp = new Color(255, 255, 255, 200);
+    theme.setRangeGridlinePaint(transp);
+    theme.setDomainGridlinePaint(transp);
+
+    theme.setAxisLinePaint(Color.white);
+
+    theme.setMasterFontColor(Color.WHITE);
+    // axis offset
+    theme.setAxisOffset(new RectangleInsets(0, 0, 0, 0));
+    return theme;
+  }
+
+  /**
+   * Creates the theme called "Karst". In this theme, the charts have a blue background and yellow
+   * lines and labels.
+   *
+   * @return The "Karst" theme.
+   */
+  public static EStandardChartTheme createKarstTheme() {
+    EStandardChartTheme theme = new EStandardChartTheme(THEME.KARST, "Karst");
+    // Fonts
+    theme.setExtraLargeFont(new Font("Arial", Font.BOLD, 20));
+    theme.setLargeFont(new Font("Arial", Font.BOLD, 11));
+    theme.setRegularFont(new Font("Arial", Font.PLAIN, 11));
+    theme.setSmallFont(new Font("Arial", Font.PLAIN, 11));
+    //
+    Paint bg = new Color(50, 50, 202);
+    //
+    theme.setTitlePaint(Color.green);
+    theme.setSubtitlePaint(Color.yellow);
+    theme.setLegendBackgroundPaint(bg);
+    theme.setLegendItemPaint(Color.yellow);
+    theme.setChartBackgroundPaint(bg);
+    theme.setPlotBackgroundPaint(bg);
+    theme.setPlotOutlinePaint(Color.yellow);
+    theme.setBaselinePaint(Color.white);
+    theme.setCrosshairPaint(Color.red);
+    theme.setLabelLinkPaint(Color.lightGray);
+    theme.setTickLabelPaint(Color.yellow);
+    theme.setAxisLabelPaint(Color.yellow);
+    theme.setShadowPaint(Color.darkGray);
+    theme.setItemLabelPaint(Color.yellow);
+    theme.setDrawingSupplier(new DefaultDrawingSupplier(
+        new Paint[] {Color.decode("0xFFFF00"), Color.decode("0x0036CC"), Color.decode("0xFF0000"),
+            Color.decode("0xFFFF7F"), Color.decode("0x6681CC"), Color.decode("0xFF7F7F"),
+            Color.decode("0xFFFFBF"), Color.decode("0x99A6CC"), Color.decode("0xFFBFBF"),
+            Color.decode("0xA9A938"), Color.decode("0x2D4587")},
+        new Paint[] {Color.decode("0xFFFF00"), Color.decode("0x0036CC")},
+        new Stroke[] {new BasicStroke(2.0f)}, new Stroke[] {new BasicStroke(0.5f)},
+        DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE));
+    theme.setErrorIndicatorPaint(Color.lightGray);
+    theme.setGridBandPaint(new Color(255, 255, 255, 20));
+    theme.setGridBandAlternatePaint(new Color(255, 255, 255, 40));
+
+    // axis
+    Color transp = new Color(255, 255, 255, 200);
+    theme.setRangeGridlinePaint(transp);
+    theme.setDomainGridlinePaint(transp);
+
+    theme.setAxisLinePaint(Color.yellow);
+    theme.setMasterFontColor(Color.yellow);
+
+    // axis offset
+    theme.setAxisOffset(new RectangleInsets(0, 0, 0, 0));
+    return theme;
+  }
+
+
+  public static EStandardChartTheme getStandardTheme() {
+    return createChartTheme(standardTheme);
+  }
+
+  public static void setStandardTheme(THEME theme) {
+    standardTheme = theme;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/chartthemes/ChartThemeParameters.java
+++ b/src/main/java/io/github/mzmine/chartbasics/chartthemes/ChartThemeParameters.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.chartthemes;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.util.List;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.title.Title;
+import net.sf.mzmine.framework.fontspecs.FontSpecs;
+import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
+import net.sf.mzmine.parameters.parametertypes.ColorParameter;
+import net.sf.mzmine.parameters.parametertypes.FontParameter;
+import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
+import net.sf.mzmine.parameters.parametertypes.StringParameter;
+
+/**
+ * JFreeChart theme settings for {@link EStandardChartTheme}s
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartThemeParameters extends SimpleParameterSet {
+
+  public static final BooleanParameter showTitle = new BooleanParameter("Show title", "", false);
+  public static final OptionalParameter<StringParameter> changeTitle =
+      new OptionalParameter<StringParameter>(new StringParameter("Change title", "", ""));
+  public static final BooleanParameter showLegends =
+      new BooleanParameter("Show legends", "", false);
+
+  public static final OptionalParameter<StringParameter> xlabel =
+      new OptionalParameter<StringParameter>(new StringParameter("Change x", "", "x"));
+  public static final OptionalParameter<StringParameter> ylabel =
+      new OptionalParameter<StringParameter>(new StringParameter("Change y", "", "y"));
+
+  public static final ColorParameter color =
+      new ColorParameter("Background", "Background color", Color.WHITE);
+
+  public static final FontParameter masterFont =
+      new FontParameter("Master", "Master font changes all fonts",
+          new FontSpecs(Color.BLACK, new Font("Arial", Font.PLAIN, 11)));
+  public static final FontParameter titleFont = new FontParameter("Title", "Title font",
+      new FontSpecs(Color.BLACK, new Font("Arial", Font.BOLD, 11)));
+  public static final FontParameter captionFont = new FontParameter("Captions", "Caption font",
+      new FontSpecs(Color.BLACK, new Font("Arial", Font.BOLD, 11)));
+  public static final FontParameter labelFont = new FontParameter("Labels", "Label font",
+      new FontSpecs(Color.BLACK, new Font("Arial", Font.PLAIN, 9)));
+
+  public static final OptionalParameter<ColorParameter> xGridPaint =
+      new OptionalParameter<ColorParameter>(new ColorParameter("X grid",
+          "Enable/Disable the x grid and set the line color", Color.black));
+  public static final OptionalParameter<ColorParameter> yGridPaint =
+      new OptionalParameter<ColorParameter>(new ColorParameter("Y grid",
+          "Enable/Disable the y grid and set the line color", Color.black));
+
+  public static final BooleanParameter showXAxis = new BooleanParameter("Show x axis", "", true);
+  public static final BooleanParameter showYAxis = new BooleanParameter("Show y axis", "", true);
+
+
+  public ChartThemeParameters() {
+    super(new Parameter[] {showLegends, showTitle, changeTitle, xlabel, ylabel,color, masterFont,
+        titleFont, captionFont, labelFont, xGridPaint, yGridPaint, showXAxis, showYAxis});
+    changeTitle.setValue(false);
+    xlabel.setValue(false);
+    ylabel.setValue(false);
+    xGridPaint.setValue(false);
+    yGridPaint.setValue(false);
+  }
+
+
+  public void applyToChart(JFreeChart chart) {
+    // apply chart settings
+    boolean showTitle = this.getParameter(ChartThemeParameters.showTitle).getValue();
+    boolean changeTitle = this.getParameter(ChartThemeParameters.changeTitle).getValue();
+    String title = this.getParameter(ChartThemeParameters.changeTitle).getEmbeddedParameter().getValue();
+    boolean showLegends = this.getParameter(ChartThemeParameters.showLegends).getValue();
+
+    boolean usexlabel = this.getParameter(ChartThemeParameters.xlabel).getValue();
+    boolean useylabel = this.getParameter(ChartThemeParameters.ylabel).getValue();
+    String xlabel = this.getParameter(ChartThemeParameters.xlabel).getEmbeddedParameter().getValue();
+    String ylabel = this.getParameter(ChartThemeParameters.ylabel).getEmbeddedParameter().getValue();
+
+    Color gbColor = this.getParameter(ChartThemeParameters.color).getValue();
+    chart.setBackgroundPaint(gbColor);
+    chart.getPlot().setBackgroundPaint(gbColor);
+    
+    if (changeTitle)
+      chart.setTitle(title);
+    chart.getTitle().setVisible(showTitle);
+    ((List<Title>) chart.getSubtitles()).stream().forEach(t -> t.setVisible(showLegends));
+
+    if (chart.getXYPlot() != null) {
+      XYPlot p = chart.getXYPlot();
+      if (usexlabel)
+        p.getDomainAxis().setLabel(xlabel);
+      if (useylabel)
+        p.getRangeAxis().setLabel(ylabel);
+
+
+      boolean xgrid = this.getParameter(ChartThemeParameters.xGridPaint).getValue();
+      boolean ygrid = this.getParameter(ChartThemeParameters.yGridPaint).getValue();
+      Color cxgrid =
+          this.getParameter(ChartThemeParameters.xGridPaint).getEmbeddedParameter().getValue();
+      Color cygrid =
+          this.getParameter(ChartThemeParameters.yGridPaint).getEmbeddedParameter().getValue();
+      p.setDomainGridlinesVisible(xgrid);
+      p.setDomainGridlinePaint(cxgrid);
+      p.setRangeGridlinesVisible(ygrid);
+      p.setRangeGridlinePaint(cygrid);
+
+      p.getDomainAxis().setVisible(this.getParameter(ChartThemeParameters.showXAxis).getValue());
+      p.getRangeAxis().setVisible(this.getParameter(ChartThemeParameters.showYAxis).getValue());
+    }
+  }
+
+  public void applyToChartTheme(EStandardChartTheme theme) {
+    // apply chart settings
+    boolean showTitle = this.getParameter(ChartThemeParameters.showTitle).getValue();
+    boolean showLegends = this.getParameter(ChartThemeParameters.showLegends).getValue();
+    boolean showXAxis = this.getParameter(ChartThemeParameters.showXAxis).getValue();
+    boolean showYAxis = this.getParameter(ChartThemeParameters.showYAxis).getValue();
+    boolean xgrid = this.getParameter(ChartThemeParameters.xGridPaint).getValue();
+    boolean ygrid = this.getParameter(ChartThemeParameters.yGridPaint).getValue();
+    Color cxgrid = this.getParameter(ChartThemeParameters.xGridPaint).getEmbeddedParameter().getValue();
+    Color cygrid = this.getParameter(ChartThemeParameters.yGridPaint).getEmbeddedParameter().getValue();
+
+    theme.setShowTitle(showTitle);
+    theme.getShowSubtitles(showLegends);
+
+    FontSpecs master = this.getParameter(ChartThemeParameters.masterFont).getValue();
+    FontSpecs large = this.getParameter(ChartThemeParameters.titleFont).getValue();
+    FontSpecs medium = this.getParameter(ChartThemeParameters.captionFont).getValue();
+    FontSpecs small = this.getParameter(ChartThemeParameters.labelFont).getValue();
+    
+    Color gbColor = this.getParameter(ChartThemeParameters.color).getValue();
+
+    theme.setChartBackgroundPaint(gbColor);
+    theme.setPlotBackgroundPaint(gbColor);
+    
+    theme.setMasterFont(master.getFont());
+    theme.setExtraLargeFont(large.getFont());
+    theme.setLargeFont(medium.getFont());
+    theme.setRegularFont(small.getFont());
+    theme.setSmallFont(small.getFont());
+
+    theme.setMasterFontColor(master.getColor());
+    theme.setAxisLabelPaint(medium.getColor());
+    theme.setTickLabelPaint(small.getColor());
+    theme.setTitlePaint(large.getColor());
+    theme.setItemLabelPaint(small.getColor());
+    theme.setLegendItemPaint(medium.getColor());
+
+    theme.setAxisLinePaint(medium.getColor());
+
+    theme.setShowXAxis(showXAxis);
+    theme.setShowYAxis(showYAxis);
+    theme.setShowXGrid(xgrid);
+    theme.setShowYGrid(ygrid);
+    theme.setDomainGridlinePaint(cxgrid);
+    theme.setRangeGridlinePaint(cygrid);
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/chartthemes/EStandardChartTheme.java
+++ b/src/main/java/io/github/mzmine/chartbasics/chartthemes/EStandardChartTheme.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.chartthemes;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Paint;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.StandardChartTheme;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.renderer.category.StandardBarPainter;
+import org.jfree.chart.renderer.xy.StandardXYBarPainter;
+import org.jfree.chart.title.PaintScaleLegend;
+import net.sf.mzmine.chartbasics.chartthemes.ChartThemeFactory.THEME;
+
+
+/**
+ * More options for the StandardChartTheme
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class EStandardChartTheme extends StandardChartTheme {
+  private static final long serialVersionUID = 1L;
+
+  public static final String XML_DESC = "ChartTheme";
+  // master font
+  protected Font masterFont;
+  protected Color masterFontColor;
+
+  // Chart appearance
+  protected boolean isAntiAliased = true;
+  // orientation : 0 - 2 (90 CW)
+
+  protected boolean isShowTitle = false;
+  protected boolean subtitleVisible = false;
+
+  protected Paint axisLinePaint = Color.black;
+  protected THEME themeID;
+
+  protected boolean showXGrid = false, showYGrid = false;
+  protected boolean showXAxis = true, showYAxis = true;
+
+
+  public EStandardChartTheme(THEME themeID, String name) {
+    super(name);
+    this.themeID = themeID;
+
+    setBarPainter(new StandardBarPainter());
+    setXYBarPainter(new StandardXYBarPainter());
+
+    // in theme
+    setAntiAliased(false);
+    setNoBackground(false);
+    // general
+
+    isAntiAliased = true;
+
+    masterFont = new Font("Arial", Font.PLAIN, 11);
+    masterFontColor = Color.black;
+  }
+
+  public void setAll(boolean antiAlias, boolean showTitle, boolean noBG, Color cBG, Color cPlotBG,
+      boolean showXGrid, boolean showYGrid, boolean showXAxis, boolean showYAxis, Font fMaster,
+      Color cMaster, Font fAxesT, Color cAxesT, Font fAxesL, Color cAxesL, Font fTitle,
+      Color cTitle) {
+    this.setAntiAliased(antiAlias);
+    this.setShowTitle(showTitle);
+    this.setNoBackground(noBG);
+    this.setShowXGrid(showXGrid);
+    this.setShowYGrid(showYGrid);
+    this.setShowXAxis(showXAxis);
+    this.setShowYAxis(showYAxis);
+    //
+
+    this.setExtraLargeFont(fTitle);
+    this.setLargeFont(fAxesT);
+    this.setRegularFont(fAxesL);
+    this.setAxisLabelPaint(cAxesT);
+    this.setTickLabelPaint(cAxesL);
+    this.setTitlePaint(cTitle);
+
+    this.setChartBackgroundPaint(cBG);
+    this.setPlotBackgroundPaint(cPlotBG);
+    this.setLegendBackgroundPaint(cBG);
+
+    masterFont = fMaster;
+    masterFontColor = cMaster;
+  }
+
+
+  @Override
+  public void apply(JFreeChart chart) {
+    // TODO Auto-generated method stub
+    super.apply(chart);
+    //
+    chart.getXYPlot().setDomainGridlinesVisible(showXGrid);
+    chart.getXYPlot().setRangeGridlinesVisible(showYGrid);
+    // all axes
+    for (int i = 0; i < chart.getXYPlot().getDomainAxisCount(); i++) {
+      NumberAxis a = (NumberAxis) chart.getXYPlot().getDomainAxis(i);
+      a.setTickMarkPaint(axisLinePaint);
+      a.setAxisLinePaint(axisLinePaint);
+      // visible?
+      a.setVisible(showXAxis);
+    }
+    for (int i = 0; i < chart.getXYPlot().getRangeAxisCount(); i++) {
+      NumberAxis a = (NumberAxis) chart.getXYPlot().getRangeAxis(i);
+      a.setTickMarkPaint(axisLinePaint);
+      a.setAxisLinePaint(axisLinePaint);
+      // visible?
+      a.setVisible(showYAxis);
+    }
+    // apply bg
+    chart.setBackgroundPaint(this.getChartBackgroundPaint());
+    chart.getPlot().setBackgroundPaint(this.getPlotBackgroundPaint());
+
+    for (int i = 0; i < chart.getSubtitleCount(); i++) {
+      // visible?
+      chart.getSubtitle(i).setVisible(subtitleVisible);
+      //
+      if (PaintScaleLegend.class.isAssignableFrom(chart.getSubtitle(i).getClass()))
+        ((PaintScaleLegend) chart.getSubtitle(i))
+            .setBackgroundPaint(this.getChartBackgroundPaint());
+    }
+    if (chart.getLegend() != null)
+      chart.getLegend().setBackgroundPaint(this.getChartBackgroundPaint());
+
+    //
+    chart.setAntiAlias(isAntiAliased());
+    chart.getTitle().setVisible(isShowTitle());
+    chart.getPlot().setBackgroundAlpha(isNoBackground() ? 0 : 1);
+  }
+
+  public boolean isNoBackground() {
+    return ((Color) this.getPlotBackgroundPaint()).getAlpha() == 0;
+  }
+
+  public void setNoBackground(boolean state) {
+    Color c = ((Color) this.getPlotBackgroundPaint());
+    Color cchart = ((Color) this.getChartBackgroundPaint());
+    this.setPlotBackgroundPaint(new Color(c.getRed(), c.getGreen(), c.getBlue(), state ? 0 : 255));
+    this.setChartBackgroundPaint(
+        new Color(cchart.getRed(), cchart.getGreen(), cchart.getBlue(), state ? 0 : 255));
+    this.setLegendBackgroundPaint(
+        new Color(cchart.getRed(), cchart.getGreen(), cchart.getBlue(), state ? 0 : 255));
+  }
+
+  // GETTERS AND SETTERS
+  public Paint getAxisLinePaint() {
+    return axisLinePaint;
+  }
+
+  public boolean isShowTitle() {
+    return isShowTitle;
+  }
+
+  public boolean isAntiAliased() {
+    return isAntiAliased;
+  }
+
+  public void setAntiAliased(boolean isAntiAliased) {
+    this.isAntiAliased = isAntiAliased;
+  }
+
+  public void setShowTitle(boolean showTitle) {
+    isShowTitle = showTitle;
+  }
+
+  public void setAxisLinePaint(Paint axisLinePaint) {
+    this.axisLinePaint = axisLinePaint;
+  }
+
+  public THEME getID() {
+    return themeID;
+  }
+
+  public void setID(THEME themeID) {
+    this.themeID = themeID;
+  }
+
+  public void setShowXGrid(boolean showXGrid) {
+    this.showXGrid = showXGrid;
+  }
+
+  public void setShowYGrid(boolean showYGrid) {
+    this.showYGrid = showYGrid;
+  }
+
+  public boolean isShowXGrid() {
+    return showXGrid;
+  }
+
+  public boolean isShowYGrid() {
+    return showYGrid;
+  }
+
+  public boolean isShowXAxis() {
+    return showXAxis;
+  }
+
+  public void setShowXAxis(boolean showXAxis) {
+    this.showXAxis = showXAxis;
+  }
+
+  public boolean isShowYAxis() {
+    return showYAxis;
+  }
+
+  public void setShowYAxis(boolean showYAxis) {
+    this.showYAxis = showYAxis;
+  }
+
+  public Font getMasterFont() {
+    return masterFont;
+  }
+
+  public Color getMasterFontColor() {
+    return masterFontColor;
+  }
+
+  public void setMasterFont(Font masterFont) {
+    this.masterFont = masterFont;
+  }
+
+  public void setMasterFontColor(Color masterFontColor) {
+    this.masterFontColor = masterFontColor;
+  }
+
+  public void getShowSubtitles(boolean subtitleVisible) {
+    this.subtitleVisible = subtitleVisible;
+  }
+
+  public boolean isShowSubtitles() {
+    return subtitleVisible;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGesture.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGesture.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures;
+
+import java.awt.event.MouseEvent;
+import java.util.List;
+import java.util.stream.Stream;
+import org.jfree.chart.entity.AxisEntity;
+import org.jfree.chart.entity.CategoryItemEntity;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.entity.JFreeChartEntity;
+import org.jfree.chart.entity.LegendItemEntity;
+import org.jfree.chart.entity.PlotEntity;
+import org.jfree.chart.entity.TitleEntity;
+import org.jfree.chart.entity.XYAnnotationEntity;
+import org.jfree.chart.entity.XYItemEntity;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.title.TextTitle;
+import net.sf.mzmine.chartbasics.gui.swing.ChartGestureMouseAdapter;
+import net.sf.mzmine.chartbasics.gui.wrapper.MouseEventWrapper;
+
+/**
+ * {@link ChartGesture}s are part of {@link ChartGestureEvent} which are generated and processed by
+ * the {@link ChartGestureMouseAdapter}. Processing can be performed in multiple
+ * {@link ChartGestureHandler}s. <br>
+ * ChartGestures can be filtered by <br>
+ * - MouseEvents (also mouse wheel)<br>
+ * - Mouse buttons <br>
+ * - Keyboard keys (Ctrl, Alt, Shift) <br>
+ * - ChartEntities (general like AXIS or specific like DOMAIN_AXIS) <br>
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartGesture {
+  // ########################################################################
+  // statics
+  public static final ChartGesture ALL = new ChartGesture(Entity.ALL, Event.ALL, Button.ALL);
+  //
+  private Entity entity;
+  private Event[] event;
+  private Key key;
+  private Button button = Button.BUTTON1;
+
+  /**
+   * Target ChartEntity and mouse Event Entity.All and Event.ALL do not filter BUTTON.BUTTON1 is
+   * used
+   * 
+   * @param entity
+   * @param event
+   */
+  public ChartGesture(Entity entity, Event event) {
+    this(entity, event, Button.BUTTON1);
+  }
+
+  /**
+   * Target ChartEntity and mouse Event Entity.All and Event.ALL do not filter BUTTON.BUTTON1 is
+   * used
+   * 
+   * @param entity
+   * @param event
+   * @param key
+   */
+  public ChartGesture(Entity entity, Event event, Key key) {
+    this(entity, event, Button.BUTTON1, key);
+  }
+
+  /**
+   * Target ChartEntity and mouse Event Entity.All and Event.ALL do not filter BUTTON.BUTTON1 is
+   * used
+   * 
+   * @param entity
+   * @param event
+   */
+  public ChartGesture(Entity entity, Event[] event) {
+    this(entity, event, Button.BUTTON1);
+  }
+
+  /**
+   * Target ChartEntity and mouse Event Entity.All and Event.ALL do not filter
+   * 
+   * @param entity
+   * @param event
+   * @param button MouseEvent.BUTTON...
+   */
+  public ChartGesture(Entity entity, Event event, Button button) {
+    this(entity, new Event[] {event}, button);
+  }
+
+  /**
+   * Target ChartEntity and mouse Event Entity.All and Event.ALL do not filter
+   * 
+   * @param entity
+   * @param event
+   * @param button MouseEvent.BUTTON...
+   */
+  public ChartGesture(Entity entity, Event event, Button button, Key key) {
+    this(entity, new Event[] {event}, button, key);
+  }
+
+  /**
+   * Target ChartEntity and mouse Event Entity.All and Event.ALL do not filter
+   * 
+   * @param entity
+   * @param event
+   * @param button MouseEvent.BUTTON...
+   */
+  public ChartGesture(Entity entity, Event[] event, Button button) {
+    this(entity, event, button, null);
+  }
+
+  /**
+   * Target ChartEntity and mouse Event Entity.All and Event.ALL do not filter
+   * 
+   * @param entity
+   * @param event
+   * @param button MouseEvent.BUTTON...
+   */
+  public ChartGesture(Entity entity, Event[] event, Button button, Key key) {
+    this.entity = entity;
+    this.event = event;
+    this.button = button;
+    this.key = key;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ChartGesture))
+      return false;
+    else {
+      ChartGesture g = (ChartGesture) obj;
+      return this.getEntity().equals(g.getEntity()) && this.getEvent().equals(g.getEvent())
+          && this.getButton().equals(g.getButton()) && this.getKey().equals(g.getKey());
+    }
+  }
+
+  /**
+   * True if the argument fits to this gesture. The entity and event have to fit
+   * 
+   * @param g
+   */
+  public boolean filter(ChartGesture g) {
+    return this.getEntity().filter(g.getEntity())
+        && (this.getButton() == null || this.getButton().filter(g.getButton())) &&
+        // any element fits to any element?
+        Stream.of(this.getEvent())
+            .anyMatch(e1 -> Stream.of(g.getEvent()).anyMatch(e2 -> e1.filter(e2)))
+        &&
+        // key match?
+        (this.getKey() == null || this.getKey().filter(g.getKey()));
+  }
+
+
+  public Key getKey() {
+    return key;
+  }
+
+  public void setKey(Key key) {
+    this.key = key;
+  }
+
+  public Entity getEntity() {
+    return entity;
+  }
+
+  public Event[] getEvent() {
+    return event;
+  }
+
+  public void setEntity(Entity entity) {
+    this.entity = entity;
+  }
+
+  public void setEvent(Event[] event) {
+    this.event = event;
+  }
+
+  /**
+   * The gesture entity type
+   * 
+   * @param entity
+   * @return
+   */
+  public static Entity getGestureEntity(ChartEntity entity) {
+    return Entity.getGestureEntity(entity);
+  }
+
+  /**
+   * returns the BUTTON for a MouseEvent.BUTTON
+   * 
+   * @param mouseeventbutton
+   * @return
+   */
+  public static Button getButton(int mouseeventbutton) {
+    return Button.getButton(mouseeventbutton);
+  }
+
+  public Button getButton() {
+    return button;
+  }
+
+  public void setButton(Button button) {
+    this.button = button;
+  }
+
+  @Override
+  public String toString() {
+    return (button == null ? "" : (button.toString() + " "))
+        + (key == null ? "" : key.toString() + " ") + event[0].toString() + " " + entity.toString();
+  }
+
+  // ########################################################################
+  // Filter section
+  // Event, Entity, Button, Key
+  /**
+   * The mouse event (filter)
+   */
+  public enum Event {
+    ALL, CLICK, DOUBLE_CLICK, PRESSED, RELEASED, MOVED, DRAGGED, ENTERED, EXITED, MOUSE_WHEEL;
+
+    /**
+     * True if e fits into this event
+     * 
+     * @param e
+     * @return
+     */
+    public boolean filter(Event e) {
+      if (this.equals(ALL))
+        return true;
+      else
+        return this.equals(e);
+    }
+
+    @Override
+    public String toString() {
+      return super.toString().replaceAll("_", " ");
+    }
+  }
+  /**
+   * The chart entity (filter)
+   */
+  public enum Entity {
+    ALL, NONE, GENERAL, AXIS, DOMAIN_AXIS, RANGE_AXIS, PLOT, LEGEND_ITEM, XY_ITEM, XY_ANNOTATION, CATEGORY_ITEM, TITLE, TEXT_TITLE, NON_TEXT_TITLE, JFREECHART;
+
+    /**
+     * True if e fits into this entity
+     * 
+     * @param e
+     * @return
+     */
+    public boolean filter(Entity e) {
+      if (this.equals(ALL))
+        return true;
+      if (this.equals(AXIS))
+        return e.toString().endsWith("AXIS");
+      if (this.equals(TITLE))
+        return e.toString().endsWith("TITLE");
+      else
+        return this.equals(e);
+    }
+
+    /**
+     * The gesture entity type
+     * 
+     * @param entity
+     * @return
+     */
+    public static Entity getGestureEntity(ChartEntity entity) {
+      if (entity == null)
+        return NONE;
+      if (entity instanceof PlotEntity)
+        return PLOT;
+      if (entity instanceof AxisEntity) {
+        AxisEntity e = (AxisEntity) entity;
+        if (e.getAxis().getPlot() instanceof XYPlot) {
+          XYPlot plot = ((XYPlot) e.getAxis().getPlot());
+          for (int i = 0; i < plot.getDomainAxisCount(); i++)
+            if (plot.getDomainAxis(i).equals(e.getAxis()))
+              return DOMAIN_AXIS;
+          for (int i = 0; i < plot.getRangeAxisCount(); i++)
+            if (plot.getRangeAxis(i).equals(e.getAxis()))
+              return RANGE_AXIS;
+        }
+        // else return basic axis
+        return AXIS;
+      }
+      if (entity instanceof LegendItemEntity)
+        return LEGEND_ITEM;
+      if (entity instanceof XYItemEntity)
+        return XY_ITEM;
+      if (entity instanceof XYAnnotationEntity)
+        return XY_ANNOTATION;
+      if (entity instanceof TitleEntity) {
+        if (((TitleEntity) entity).getTitle() instanceof TextTitle)
+          return TEXT_TITLE;
+        else
+          return NON_TEXT_TITLE;
+      }
+      if (entity instanceof JFreeChartEntity)
+        return JFREECHART;
+      if (entity instanceof CategoryItemEntity)
+        return CATEGORY_ITEM;
+      return GENERAL;
+    }
+
+    @Override
+    public String toString() {
+      return super.toString().replaceAll("_", " ");
+    }
+  }
+
+  public enum Button {
+    ALL, BUTTON1, BUTTON2, BUTTON3;
+
+    /**
+     * True if e fits into this button
+     * 
+     * @param e
+     * @return
+     */
+    public boolean filter(Button e) {
+      if (this.equals(ALL))
+        return true;
+      else
+        return this.equals(e);
+    }
+
+    /**
+     * returns the BUTTON for a MouseEvent.BUTTON
+     * 
+     * @param mouseeventbutton
+     * @return
+     */
+    public static Button getButton(int mouseeventbutton) {
+      switch (mouseeventbutton) {
+        case MouseEvent.BUTTON1:
+          return BUTTON1;
+        case MouseEvent.BUTTON2:
+          return BUTTON2;
+        case MouseEvent.BUTTON3:
+          return BUTTON3;
+      }
+      return null;
+    }
+  }
+
+  public enum Key {
+    ALL, NONE, ALT, SHIFT, CTRL, CTRL_SHIFT, ALT_SHIFT, CTRL_ALT, CTRL_ALT_SHIFT;
+
+    /**
+     * True if e fits into this button
+     * 
+     * @param e
+     * @return
+     */
+    public boolean filter(Key e) {
+      if (this.equals(ALL))
+        return true;
+      else if (this.equals(NONE))
+        return e == null || e.equals(NONE);
+      else
+        return this.equals(e);
+    }
+
+    /**
+     * True if e fits into this button
+     * 
+     * @param e
+     * @return
+     */
+    public boolean filter(MouseEventWrapper e) {
+      switch (this) {
+        case ALL:
+          return true;
+        case NONE:
+          return !(e.isAltDown() || e.isControlDown() || e.isShiftDown());
+        case ALT:
+          return e.isAltDown() && !e.isControlDown() && !e.isShiftDown();
+        case CTRL:
+          return !e.isAltDown() && e.isControlDown() && !e.isShiftDown();
+        case SHIFT:
+          return !e.isAltDown() && !e.isControlDown() && e.isShiftDown();
+        case CTRL_SHIFT:
+          return !e.isAltDown() && e.isControlDown() && e.isShiftDown();
+        case CTRL_ALT:
+          return e.isAltDown() && e.isControlDown() && !e.isShiftDown();
+        case CTRL_ALT_SHIFT:
+          return e.isAltDown() && e.isControlDown() && e.isShiftDown();
+        case ALT_SHIFT:
+          return e.isAltDown() && !e.isControlDown() && e.isShiftDown();
+      }
+      return false;
+    }
+
+    /**
+     * Converts a list to a Key
+     * 
+     * @param keys
+     * @return
+     */
+    public static Key fromList(List<Key> keys) {
+      if (keys == null || keys.size() == 0)
+        return NONE;
+      if (keys.contains(ALL))
+        return ALL;
+      if (keys.contains(CTRL)) {
+        if (keys.size() == 1)
+          return CTRL;
+        else if (keys.contains(SHIFT)) {
+          if (keys.contains(ALT))
+            return CTRL_ALT_SHIFT;
+          else
+            return CTRL_SHIFT;
+        } else if (keys.contains(ALT)) {
+          return CTRL_ALT;
+        }
+      } else if (keys.contains(SHIFT)) {
+        if (keys.size() == 1)
+          return SHIFT;
+        else if (keys.contains(ALT))
+          return ALT_SHIFT;
+      } else if (keys.contains(ALT)) {
+        if (keys.size() == 1)
+          return ALT;
+      }
+      // else
+      return NONE;
+    }
+
+    @Override
+    public String toString() {
+      return super.toString().replace("_", " ");
+    }
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureDragDiffEvent.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureDragDiffEvent.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures;
+
+import org.jfree.chart.axis.ValueAxis;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureDragDiffHandler.Orientation;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+
+/**
+ * This event gets consumed by a {@link ChartGestureDragDiffHandler}
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartGestureDragDiffEvent {
+
+  private ChartGestureEvent firstEvent, lastEvent, latestEvent;
+  private Orientation orient;
+  // drag start and difference between last and latestEvent
+  private double start, diff;
+
+  public ChartGestureDragDiffEvent(ChartGestureEvent firstEvent, ChartGestureEvent lastEvent,
+      ChartGestureEvent latestEvent, double start, double diff, Orientation orient) {
+    super();
+    this.firstEvent = firstEvent;
+    this.latestEvent = latestEvent;
+    this.lastEvent = lastEvent;
+    this.start = start;
+    this.diff = diff;
+    this.orient = orient;
+  }
+
+  public void setLatestEvent(ChartGestureEvent latestEvent) {
+    lastEvent = this.latestEvent;
+    this.latestEvent = latestEvent;
+  }
+
+  /**
+   * First event (usually Event.PRESSED)
+   * 
+   * @return
+   */
+  public ChartGestureEvent getFirstEvent() {
+    return firstEvent;
+  }
+
+  /**
+   * Event previous to latest event
+   * 
+   * @return
+   */
+  public ChartGestureEvent getLastEvent() {
+    return lastEvent;
+  }
+
+  public ChartGestureEvent getLatestEvent() {
+    return latestEvent;
+  }
+
+  /**
+   * Start value of first event in data space
+   * 
+   * @return
+   */
+  public double getStart() {
+    return start;
+  }
+
+  /**
+   * Difference value of the last two eventsin data space
+   * 
+   * @return
+   */
+  public double getDiff() {
+    return diff;
+  }
+
+  public Entity getEntity() {
+    return firstEvent.getGesture().getEntity();
+  }
+
+  public ChartViewWrapper getChartWrapper() {
+    return firstEvent.getChartWrapper();
+  }
+
+  /**
+   * The ValueAxis of this event's entity or null if the entity is different to an AxisEntity or if
+   * the axis is not a ValueAxis
+   * 
+   * @return
+   */
+  public ValueAxis getAxis() {
+    return firstEvent.getAxis();
+  }
+
+  public Orientation getOrient() {
+    return orient;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureDragDiffHandler.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureDragDiffHandler.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures;
+
+import java.awt.geom.Point2D;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.entity.AxisEntity;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.plot.PlotOrientation;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Button;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Event;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Key;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+import net.sf.mzmine.chartbasics.gui.wrapper.MouseEventWrapper;
+
+/**
+ * The {@link ChartGestureDragDiffHandler} consumes primary mouse events to generate
+ * {@link ChartGestureDragDiffEvent}s. These events are then processed by one or multiple
+ * {@link Consumer}s. Each Consumer has a specific {@link Key} filter. Key and Consumer array have
+ * to be sorted accordingly.
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartGestureDragDiffHandler extends ChartGestureHandler {
+  private Logger logger = Logger.getLogger(this.getClass().getName());
+
+  public enum Orientation {
+    VERTICAL, HORIZONTAL;
+  }
+
+  protected Key[] key;
+  protected Consumer<ChartGestureDragDiffEvent> dragDiffHandler[];
+  // default orientation
+  protected Orientation orient = Orientation.HORIZONTAL;
+
+  public ChartGestureDragDiffHandler(ChartGesture.Entity entity, Button button, Key[] key,
+      Consumer<ChartGestureDragDiffEvent> dragDiffHandler[]) {
+    this(entity, button, key, dragDiffHandler, null);
+  }
+
+  public ChartGestureDragDiffHandler(ChartGesture.Entity entity, Button button, Key[] key,
+      Consumer<ChartGestureDragDiffEvent> dragDiffHandler[], Orientation defaultOrientation) {
+    super(new ChartGesture(entity, new Event[] {Event.RELEASED, Event.PRESSED, Event.DRAGGED},
+        button, Key.ALL));
+    /**
+     * Handles PRESSED, DRAGGED, RELEASED Events Fires the correct DragDiffHandlers for the Key
+     * filter
+     */
+    setConsumer(createConsumer());
+    // super() finished
+    this.key = key;
+    this.dragDiffHandler = dragDiffHandler;
+    this.orient = defaultOrientation;
+  }
+
+  /**
+   * use default orientation or orientation of axis
+   * 
+   * @param event
+   * @return
+   */
+  public Orientation getOrientation(ChartGestureEvent event) {
+    ChartEntity ce = event.getEntity();
+    if (ce instanceof AxisEntity) {
+      JFreeChart chart = event.getChart();
+      PlotOrientation plotorient = PlotOrientation.HORIZONTAL;
+      if (chart.getXYPlot() != null)
+        plotorient = chart.getXYPlot().getOrientation();
+      else if (chart.getCategoryPlot() != null)
+        plotorient = chart.getCategoryPlot().getOrientation();
+
+      Entity entity = event.getGesture().getEntity();
+      if ((entity.equals(Entity.DOMAIN_AXIS) && plotorient.equals(PlotOrientation.VERTICAL))
+          || (entity.equals(Entity.RANGE_AXIS) && plotorient.equals(PlotOrientation.HORIZONTAL)))
+        orient = Orientation.HORIZONTAL;
+      else
+        orient = Orientation.VERTICAL;
+    }
+    return orient;
+  }
+
+  /**
+   * Handle PRESSED, DRAGGED, RELEASED events to generate drag diff events
+   * 
+   * @return
+   */
+  private Consumer<ChartGestureEvent> createConsumer() {
+    return new Consumer<ChartGestureEvent>() {
+      // variables
+      boolean wasMouseZoomable = false;
+      Point2D last = null, first = null;
+      ChartGestureEvent startEvent = null, lastEvent = null;
+
+      @Override
+      public void accept(ChartGestureEvent event) {
+        ChartViewWrapper chartPanel = event.getChartWrapper();
+        JFreeChart chart = chartPanel.getChart();
+        MouseEventWrapper e = event.getMouseEvent();
+
+        // released?
+        if (event.checkEvent(Event.RELEASED)) {
+          chartPanel.setMouseZoomable(wasMouseZoomable);
+          last = null;
+        } else if (event.checkEvent(Event.PRESSED)) {
+          // get data space coordinates
+          last = chartPanel.mouseXYToPlotXY(e.getX(), e.getY());
+          first = last;
+          startEvent = event;
+          lastEvent = event;
+          if (last != null) {
+            wasMouseZoomable = chartPanel.isMouseZoomable();
+            chartPanel.setMouseZoomable(false);
+          }
+        } else if (event.checkEvent(Event.DRAGGED)) {
+          if (last != null) {
+            // get data space coordinates
+            Point2D released = chartPanel.mouseXYToPlotXY(e.getX(), e.getY());
+            if (released != null) {
+              double offset = 0;
+              double start = 0;
+              // scroll x
+              if (getOrientation(event).equals(Orientation.HORIZONTAL)) {
+                offset = -(released.getX() - last.getX());
+                start = first.getX();
+              }
+              // scroll y
+              else {
+                offset = -(released.getY() - last.getY());
+                start = first.getY();
+              }
+
+              // new dragdiff event
+              ChartGestureDragDiffEvent dragEvent = new ChartGestureDragDiffEvent(startEvent,
+                  lastEvent, event, start, offset, orient);
+              // scroll / zoom / do anything with this new event
+              // choose handler by key filter
+              for (int i = 0; i < dragDiffHandler.length; i++)
+                if (key[i].filter(event.getMouseEvent()))
+                  dragDiffHandler[i].accept(dragEvent);
+              // set last event
+              lastEvent = event;
+              // save updated last
+              last = chartPanel.mouseXYToPlotXY(e.getX(), e.getY());
+            }
+          }
+        }
+      }
+    };
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureEvent.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureEvent.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures;
+
+import java.awt.event.MouseEvent;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.entity.AxisEntity;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.fx.ChartViewer;
+import org.jfree.chart.plot.PlotOrientation;
+import javafx.scene.input.ScrollEvent;
+import net.sf.mzmine.chartbasics.ChartLogics;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Event;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Key;
+import net.sf.mzmine.chartbasics.gui.swing.ChartGestureMouseAdapter;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+import net.sf.mzmine.chartbasics.gui.wrapper.MouseEventWrapper;
+
+/**
+ * {@link ChartGesture}s are part of {@link ChartGestureEvent} which are generated and processed by
+ * the {@link ChartGestureMouseAdapter}. Processing can be performed in multiple
+ * {@link ChartGestureHandler}s. <br>
+ * ChartGestures can be filtered by <br>
+ * - MouseEvents<br>
+ * - Mouse buttons <br>
+ * - Keyboard keys (Ctrl, Alt, Shift) <br>
+ * - ChartEntities (general like AXIS or specific like DOMAIN_AXIS) <br>
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartGestureEvent { // ChartPanel or ChartCanvas
+  // ChartPanel or ChartCanvas
+  private ChartViewWrapper cp;
+
+  //
+  private MouseEventWrapper mouseEvent;
+  private ChartGesture gesture;
+  private ChartEntity entity;
+
+  public ChartGestureEvent(ChartPanel cp, MouseEvent mEvent, ChartEntity entity,
+      ChartGesture gesture) {
+    this(new ChartViewWrapper(cp), new MouseEventWrapper(mEvent), entity, gesture);
+  }
+
+  public ChartGestureEvent(ChartViewer cp, javafx.scene.input.MouseEvent mEvent, ChartEntity entity,
+      ChartGesture gesture) {
+    this(new ChartViewWrapper(cp), new MouseEventWrapper(mEvent), entity, gesture);
+  }
+
+  public ChartGestureEvent(ChartViewer cp, ScrollEvent mEvent, ChartEntity entity,
+      ChartGesture gesture) {
+    this(new ChartViewWrapper(cp), new MouseEventWrapper(mEvent), entity, gesture);
+  }
+
+  public ChartGestureEvent(ChartViewWrapper cp, MouseEventWrapper mEvent, ChartEntity entity,
+      ChartGesture gesture) {
+    super();
+    this.cp = cp;
+    this.mouseEvent = mEvent;
+    this.gesture = gesture;
+    this.entity = entity;
+
+    if (mouseEvent != null) {
+      // extract keys and set to gesture
+      ArrayList<Key> keys = new ArrayList<Key>();
+      if (mouseEvent.isAltDown())
+        keys.add(Key.ALT);
+      if (mouseEvent.isControlDown())
+        keys.add(Key.CTRL);
+      if (mouseEvent.isShiftDown())
+        keys.add(Key.SHIFT);
+      gesture.setKey(Key.fromList(keys));
+    }
+  }
+
+  public ChartGesture getGesture() {
+    return gesture;
+  }
+
+  /**
+   * ChartPanel or ChartCanvas
+   * 
+   * @return
+   */
+  public ChartViewWrapper getChartWrapper() {
+    return cp;
+  }
+
+  public JFreeChart getChart() {
+    return cp.getChart();
+  }
+
+  public boolean isChartPanel() {
+    return cp.isSwing();
+  }
+
+  public boolean isChartCanvas() {
+    return cp.isSwing();
+  }
+
+  public MouseEventWrapper getMouseEvent() {
+    return mouseEvent;
+  }
+
+  public void setGesture(ChartGesture gesture) {
+    this.gesture = gesture;
+  }
+
+  public ChartEntity getEntity() {
+    return entity;
+  }
+
+  @Override
+  public String toString() {
+    return gesture.toString() + " " + super.toString();
+  }
+
+  /**
+   * True if first gesture event equals e
+   * 
+   * @param e
+   * @return
+   */
+  public boolean checkEvent(Event e) {
+    return getGesture().getEvent()[0].equals(e);
+  }
+
+  /**
+   * The ValueAxis of this event's entity or null if the entity is different to an AxisEntity or if
+   * the axis is not a ValueAxis
+   * 
+   * @return
+   */
+  public ValueAxis getAxis() {
+    if (entity != null && entity instanceof AxisEntity
+        && ((AxisEntity) entity).getAxis() instanceof ValueAxis)
+      return (ValueAxis) ((AxisEntity) entity).getAxis();
+    else
+      return null;
+  }
+
+  /**
+   * Transforms mouse coordinates to data space coordinates. Same as
+   * {@link ChartLogics#mouseXYToPlotXY(ChartPanel, int, int)}
+   * 
+   * @param e
+   * @return
+   */
+  public Point2D getCoordinates(double x, double y) {
+    return cp.mouseXYToPlotXY(x, y);
+  }
+
+  /**
+   * Transforms mouse coordinates to data space coordinates. Same as
+   * {@link ChartLogics#mouseXYToPlotXY(ChartPanel, int, int)}
+   * 
+   * @param chartPanel
+   * @param e
+   * @return
+   */
+  public Point2D getCoordinates(int x, int y) {
+    return cp.mouseXYToPlotXY(x, y);
+  }
+  
+  /**
+   * Mouse event point
+   * @param x
+   * @param y
+   * @return 
+   */
+  public Point2D getPoint() {
+	    return mouseEvent.getPoint();
+}
+  /**
+   * Returns the index of the subplot that contains the specified
+   * (x, y) point (the "source" point).  The source point will usually
+   * come from a mouse click on a {@link org.jfree.chart.ChartPanel},
+   * and this method is then used to determine the subplot that
+   * contains the source point.
+   *
+   * @param source  the source point (in Java2D space, {@code null} not
+   * permitted).
+   *
+   * @return The subplot index (or -1 if no subplot contains {@code source}).
+   */
+  public int getSubplotIndex() {
+	  return cp.getRenderingInfo().getPlotInfo().getSubplotIndex(getPoint());
+  }
+
+  /**
+   * True if axis is vertical, false if horizontal, null if there was an error
+   * 
+   * @param axis
+   * @return
+   */
+  public Boolean isVerticalAxis(ValueAxis axis) {
+    if (axis == null)
+      return null;
+    JFreeChart chart = getChart();
+    PlotOrientation orient = PlotOrientation.HORIZONTAL;
+    if (chart.getXYPlot() != null)
+      orient = chart.getXYPlot().getOrientation();
+    else if (chart.getCategoryPlot() != null)
+      orient = chart.getCategoryPlot().getOrientation();
+    // error
+    if (orient == null)
+      return null;
+
+    Entity entity = this.getGesture().getEntity();
+    double start = 0;
+    // horizontal
+    if ((entity.equals(Entity.DOMAIN_AXIS) && orient.equals(PlotOrientation.VERTICAL))
+        || (entity.equals(Entity.RANGE_AXIS) && orient.equals(PlotOrientation.HORIZONTAL))) {
+      return false;
+    }
+    // vertical
+    else if ((entity.equals(Entity.RANGE_AXIS) && orient.equals(PlotOrientation.VERTICAL))
+        || (entity.equals(Entity.DOMAIN_AXIS) && orient.equals(PlotOrientation.HORIZONTAL))) {
+      return true;
+    }
+    // error
+    return null;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureHandler.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/ChartGestureHandler.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures;
+
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.entity.TitleEntity;
+import org.jfree.data.Range;
+import net.sf.mzmine.chartbasics.ChartLogics;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Button;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Event;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Key;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureDragDiffHandler.Orientation;
+import net.sf.mzmine.chartbasics.gestures.interf.GestureHandlerFactory;
+import net.sf.mzmine.chartbasics.gestures.standard.DragGestureHandlerDef;
+import net.sf.mzmine.chartbasics.gestures.standard.GestureHandlerDef;
+import net.sf.mzmine.chartbasics.gui.wrapper.MouseEventWrapper;
+import net.sf.mzmine.chartbasics.listener.ZoomHistory;
+
+/**
+ * The handler processes {@link ChartGestureEvent}s in a {@link Consumer}. Pre-defined handlers and
+ * drag-difference handlers can be generated. It also provides a static list of standard gesture
+ * handler definitions.
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartGestureHandler {
+  /**
+   * Some standard handlers
+   */
+  public enum Handler {
+  DEBUG, // Prints out the gesture
+  PREVIOUS_ZOOM_HISTORY, // Jump back in the zoom history
+  NEXT_ZOOM_HISTORY, // Jump forward in the zoom history
+  TITLE_REMOVER, // Remove titles (setVisible false)
+  AUTO_ZOOM_AXIS, // Auto zoom axis
+  AUTO_ZOOM_OPPOSITE_AXIS, // Auto zoom opposite axis (domain<->range axis)
+  SCROLL_AXIS, // Scroll an axis while retaining the zoom
+  SCROLL_AXIS_AND_AUTO_ZOOM, // Scroll an axis and auto zoom the other
+  ZOOM_AXIS_INCLUDE_ZERO, // Zoom an axis while holding the lowerBound
+  ZOOM_AXIS_CENTER; // Zoom and axis centered to the start gesture
+
+    @Override
+    public String toString() {
+      return super.toString().replaceAll("_", " ");
+    }
+  }
+  /**
+   * Some DragDiff standard handlers
+   */
+  public enum DragHandler {
+    AUTO_ZOOM_AXIS, // Auto zoom axis
+    AUTO_ZOOM_OPPOSITE_AXIS, // Auto zoom opposite axis (domain<->range axis)
+    SCROLL_AXIS, // Scroll an axis while retaining the zoom
+    SCROLL_AXIS_AND_AUTO_ZOOM, // Scroll an axis and auto zoom the other
+    ZOOM_AXIS_INCLUDE_ZERO, // Zoom an axis while holding the lowerBound
+    ZOOM_AXIS_CENTER; // Zoom and axis centered to the start gesture
+
+    @Override
+    public String toString() {
+      return super.toString().replaceAll("_", " ");
+    }
+  }
+
+  // static list of standard chartgestures as GestureHandlerFactories
+  // initialise + getter
+  private static List<GestureHandlerFactory> standardGestures = null;
+
+  // non static section
+  private ChartGesture gesture;
+  private Consumer<ChartGestureEvent> handler;
+
+  public ChartGestureHandler(ChartGesture gesture, Consumer<ChartGestureEvent> handler) {
+    this.gesture = gesture;
+    this.handler = handler;
+  }
+
+  public ChartGestureHandler(ChartGesture gesture) {
+    this.gesture = gesture;
+  }
+
+  public void setConsumer(Consumer<ChartGestureEvent> handler) {
+    this.handler = handler;
+  }
+
+  public void accept(ChartGestureEvent e) {
+    if (handler != null)
+      handler.accept(e);
+  }
+
+  public ChartGesture getGesture() {
+    return gesture;
+  }
+
+  public Consumer<ChartGestureEvent> getHandler() {
+    return handler;
+  }
+
+
+  /**
+   * The drag diff handler listens for PRESSED, DRAGGED and RELEASED events and is called for every
+   * range difference between two events. is a range difference between two drag events
+   * 
+   * @param handler A list of DragHandlers (predefined consumers)
+   * @param key A list of Key filters which are connected to the handler list
+   * @param entity The Entity filter
+   * @param button The Button filter
+   * @param orient Orientation of drag events (Horizontal or Vertical)
+   * @param param Parameters for specific handlers
+   */
+  public static ChartGestureHandler createDragDiffHandler(DragHandler[] handler, Key[] key,
+      Entity entity, Button button, Orientation orient, Object[] param) {
+    Consumer<ChartGestureDragDiffEvent>[] consumer = new Consumer[handler.length];
+    // create all consumers for all keys
+    try {
+      for (int i = 0; i < consumer.length; i++) {
+        consumer[i] = createDragDiffConsumer(handler[i], param);
+      }
+      return new ChartGestureDragDiffHandler(entity, button, key, consumer);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  /**
+   * Creates a predefined consumer for drag diff events
+   * 
+   * @param handler The predefined consumer
+   * @param param Parameters for specific handlers
+   * @return
+   * @throws Exception
+   */
+  public static Consumer<ChartGestureDragDiffEvent> createDragDiffConsumer(DragHandler handler,
+      Object[] param) throws Exception {
+    switch (handler) {
+      case SCROLL_AXIS:
+        return e -> {
+          ValueAxis axis = e.getAxis();
+          if (axis != null)
+            ChartLogics.offsetAxisAbsolute(axis, e.getDiff());
+        };
+      case SCROLL_AXIS_AND_AUTO_ZOOM:
+        return de -> {
+          ValueAxis axis = de.getAxis();
+          if (axis != null) {
+            ChartLogics.offsetAxisAbsolute(axis, de.getDiff());
+            if (de.getEntity().equals(Entity.DOMAIN_AXIS))
+              de.getChartWrapper().autoRangeAxis();
+            else
+              de.getChartWrapper().autoDomainAxis();
+          }
+        };
+      case AUTO_ZOOM_AXIS:
+        return de -> {
+          ValueAxis axis = de.getAxis();
+          if (axis != null)
+            ChartLogics.autoAxis(axis);
+        };
+      case AUTO_ZOOM_OPPOSITE_AXIS:
+        return de -> {
+          ValueAxis axis = de.getAxis();
+          if (axis != null) {
+            if (de.getEntity().equals(Entity.DOMAIN_AXIS))
+              de.getChartWrapper().autoRangeAxis();
+            else
+              de.getChartWrapper().autoDomainAxis();
+          }
+        };
+      case ZOOM_AXIS_INCLUDE_ZERO:
+        return de -> {
+          ValueAxis axis = de.getAxis();
+          if (axis != null) {
+            double diff = de.getDiff() / axis.getRange().getLength() * 4;
+            ChartLogics.zoomAxis(axis, diff, true);
+          }
+        };
+      case ZOOM_AXIS_CENTER:
+        return de -> {
+          ValueAxis axis = de.getAxis();
+          if (axis != null) {
+            double diff = de.getDiff() / axis.getRange().getLength() * 4;
+            ChartLogics.zoomAxis(axis, diff, de.getStart());
+          }
+        };
+      default:
+        throw new Exception("DragHandler not specified");
+    }
+  }
+
+  /**
+   * Create preset handlers
+   * 
+   * @param handler
+   * @param g
+   * @return
+   */
+  public static ChartGestureHandler createHandler(Handler handler, ChartGesture g) {
+    return createHandler(handler, g, null);
+  }
+
+  /**
+   * Create preset handlers
+   * 
+   * @param handler
+   * @param g
+   * @param param Parameters for specific handlers <br>
+   * @return
+   */
+  public static ChartGestureHandler createHandler(Handler handler, final ChartGesture g,
+      Object[] param) {
+    Consumer<ChartGestureEvent> newHandler = null;
+    switch (handler) {
+      case DEBUG:
+        newHandler = e -> System.out.println(e.toString());
+        break;
+      case PREVIOUS_ZOOM_HISTORY:
+        newHandler = e -> {
+          ZoomHistory h = e.getChartWrapper().getZoomHistory();
+          if (h != null) {
+            Range[] range = h.setPreviousPoint();
+            if (range != null && range.length > 0 && range[0] != null) {
+              ValueAxis dom = e.getChart().getXYPlot().getDomainAxis();
+              ValueAxis ran = e.getChart().getXYPlot().getRangeAxis();
+              ChartLogics.setZoomAxis(dom, range[0]);
+              ChartLogics.setZoomAxis(ran, range[1]);
+            }
+          }
+        };
+        break;
+      case NEXT_ZOOM_HISTORY:
+        newHandler = e -> {
+          ZoomHistory h = e.getChartWrapper().getZoomHistory();
+          if (h != null) {
+            Range[] range = h.setNextPoint();
+            if (range != null && range.length > 0 && range[0] != null) {
+              ValueAxis dom = e.getChart().getXYPlot().getDomainAxis();
+              ValueAxis ran = e.getChart().getXYPlot().getRangeAxis();
+              ChartLogics.setZoomAxis(dom, range[0]);
+              ChartLogics.setZoomAxis(ran, range[1]);
+            }
+          }
+        };
+        break;
+      case TITLE_REMOVER:
+        newHandler = e -> {
+          if (e.getEntity() instanceof TitleEntity) {
+            TitleEntity te = (TitleEntity) e.getEntity();
+            te.getTitle().setVisible(false);
+          }
+        };
+        break;
+      case AUTO_ZOOM_AXIS:
+        newHandler = e -> {
+          ValueAxis a = e.getAxis();
+          if (a != null)
+            ChartLogics.autoAxis(a);
+        };
+        break;
+      case AUTO_ZOOM_OPPOSITE_AXIS:
+        newHandler = e -> {
+          if (e.getGesture().getEntity().equals(Entity.AXIS)) {
+            e.getChartWrapper().autoRangeAxis();
+            e.getChartWrapper().autoDomainAxis();
+          } else if (e.getGesture().getEntity().equals(Entity.DOMAIN_AXIS))
+            e.getChartWrapper().autoRangeAxis();
+          else
+            e.getChartWrapper().autoDomainAxis();
+        };
+        break;
+      case SCROLL_AXIS:
+        newHandler = e -> {
+          ValueAxis axis = e.getAxis();
+          if (axis != null) {
+            double diff = 0.03;
+            if (e.getMouseEvent().isMouseWheelEvent()) {
+              diff = -0.10 * e.getMouseEvent().getWheelRotation();
+            }
+            ChartLogics.offsetAxis(axis, diff);
+          }
+        };
+        break;
+      case SCROLL_AXIS_AND_AUTO_ZOOM:
+        newHandler = e -> {
+          ValueAxis axis = e.getAxis();
+          if (axis != null) {
+            double diff = 0.03;
+            if (e.getMouseEvent().isMouseWheelEvent()) {
+              diff = -0.10 * e.getMouseEvent().getWheelRotation();
+            }
+            ChartLogics.offsetAxis(axis, diff);
+
+            if (e.getGesture().getEntity().equals(Entity.DOMAIN_AXIS))
+              e.getChartWrapper().autoRangeAxis();
+            else
+              e.getChartWrapper().autoDomainAxis();
+          }
+        };
+        break;
+      case ZOOM_AXIS_INCLUDE_ZERO:
+        newHandler = e -> {
+          ValueAxis axis = e.getAxis();
+          if (axis != null) {
+            double diff = 0.05;
+            if (e.getMouseEvent().isMouseWheelEvent()) {
+              diff = -0.10 * e.getMouseEvent().getWheelRotation();
+            }
+            ChartLogics.zoomAxis(axis, diff, true);
+          }
+        };
+        break;
+      case ZOOM_AXIS_CENTER:
+        newHandler = e -> {
+          ValueAxis axis = e.getAxis();
+          if (axis != null) {
+            MouseEventWrapper p = e.getMouseEvent();
+            double diff = 0.05;
+            if (e.getMouseEvent().isMouseWheelEvent()) {
+              diff = -0.10 * p.getWheelRotation();
+            }
+
+            // get data space coordinates
+            Point2D point = e.getCoordinates(p.getX(), p.getY());
+            if (point != null) {
+              // vertical ?
+              Boolean orient = e.isVerticalAxis(axis);
+              if (orient == null)
+                return;
+              else if (orient)
+                ChartLogics.zoomAxis(axis, diff, point.getY());
+              else
+                ChartLogics.zoomAxis(axis, diff, point.getX());
+            }
+          }
+        };
+        break;
+      default:
+        break;
+    }
+    if (newHandler == null)
+      return null;
+    else
+      return new ChartGestureHandler(g, newHandler);
+  }
+
+  /**
+   * A list of standard gestures
+   * 
+   * @see {@link GestureHandlerDef} {@link DragGestureHandlerDef}
+   * @return
+   */
+  public static List<GestureHandlerFactory> getStandardGestures() {
+    if (standardGestures == null)
+      initStandardGestures(true, true, true, true, true);
+    return standardGestures;
+  }
+
+  /**
+   * Generates a list of standard chart gesture
+   * 
+   * @param axisDrag
+   * @param axisWheel
+   * @param titleRemover
+   * @param zoomHistory
+   * @param axisAutoRange
+   * @return
+   */
+  public static List<GestureHandlerFactory> initStandardGestures(boolean axisDrag,
+      boolean axisWheel, boolean titleRemover, boolean zoomHistory, boolean axisAutoRange) {
+    standardGestures = new ArrayList<GestureHandlerFactory>();
+    if (axisDrag) {
+      // adds multiple gestures to one domain axis drag handler
+      // Scroll axis: DRAG mouse over domain axis
+      // Scroll + auto zoom: SHIFT + DRAG
+      // Zoom axis centered: CTRL + DRAG
+      // Zoom + auto zoom range axis: CTRL + SHIFT + DRAG
+      standardGestures.add(new DragGestureHandlerDef(
+          new DragHandler[] {DragHandler.SCROLL_AXIS, DragHandler.SCROLL_AXIS_AND_AUTO_ZOOM,
+              DragHandler.ZOOM_AXIS_CENTER, DragHandler.ZOOM_AXIS_CENTER,
+              DragHandler.AUTO_ZOOM_OPPOSITE_AXIS},
+          new Key[] {Key.NONE, Key.SHIFT, Key.CTRL, Key.CTRL_SHIFT, Key.CTRL_SHIFT},
+          Entity.DOMAIN_AXIS, Button.BUTTON1, null, null));
+
+      // Zoom range axis (include zero): DRAG
+      standardGestures
+          .add(new DragGestureHandlerDef(new DragHandler[] {DragHandler.ZOOM_AXIS_INCLUDE_ZERO},
+              new Key[] {Key.ALL}, Entity.RANGE_AXIS, Button.BUTTON1, null, null));
+    }
+    if (axisWheel) {
+      // MOUSE WHEEL on domain axis
+      // Scroll axis: WHEEL over domain axis
+      // Scroll + auto zoom: SHIFT + WHEEL
+      // Zoom axis centered: CTRL + WHEEL
+      // Zoom + auto zoom range axis: CTRL + SHIFT + WHEEL
+      standardGestures.add(new GestureHandlerDef(Handler.SCROLL_AXIS, Entity.DOMAIN_AXIS,
+          new Event[] {Event.MOUSE_WHEEL}, null, Key.NONE, null));
+      standardGestures.add(new GestureHandlerDef(Handler.SCROLL_AXIS_AND_AUTO_ZOOM,
+          Entity.DOMAIN_AXIS, new Event[] {Event.MOUSE_WHEEL}, null, Key.SHIFT, null));
+      standardGestures.add(new GestureHandlerDef(Handler.ZOOM_AXIS_CENTER, Entity.DOMAIN_AXIS,
+          new Event[] {Event.MOUSE_WHEEL}, null, Key.CTRL, null));
+      standardGestures.add(new GestureHandlerDef(Handler.ZOOM_AXIS_CENTER, Entity.DOMAIN_AXIS,
+          new Event[] {Event.MOUSE_WHEEL}, null, Key.CTRL_SHIFT, null));
+      standardGestures.add(new GestureHandlerDef(Handler.AUTO_ZOOM_OPPOSITE_AXIS,
+          Entity.DOMAIN_AXIS, new Event[] {Event.MOUSE_WHEEL}, null, Key.CTRL_SHIFT, null));
+      // Zoom range axis (include zero): MOUSE WHEEL
+      standardGestures.add(new GestureHandlerDef(Handler.ZOOM_AXIS_INCLUDE_ZERO, Entity.RANGE_AXIS,
+          new Event[] {Event.MOUSE_WHEEL}, null, Key.ALL, null));
+    }
+    if (zoomHistory) {
+      // Previous zoom history: DOUBLE CLICK on plot
+      // Next zoom history: CTRL + DOUBLE CLICK on plot
+      standardGestures.add(new GestureHandlerDef(Handler.PREVIOUS_ZOOM_HISTORY, Entity.PLOT,
+          new Event[] {Event.DOUBLE_CLICK}, Button.BUTTON1, Key.NONE, null));
+      standardGestures.add(new GestureHandlerDef(Handler.NEXT_ZOOM_HISTORY, Entity.PLOT,
+          new Event[] {Event.DOUBLE_CLICK}, Button.BUTTON1, Key.CTRL, null));
+    }
+    if (titleRemover) {
+      // Remove titles, legends: CTRL + CLICK on titles
+      standardGestures.add(new GestureHandlerDef(Handler.TITLE_REMOVER, Entity.TITLE,
+          new Event[] {Event.CLICK}, Button.BUTTON1, Key.CTRL, null));
+    }
+    if (axisAutoRange) {
+      // Auto zoom axes: DOUBLE CLICK on axis
+      standardGestures.add(new GestureHandlerDef(Handler.AUTO_ZOOM_AXIS, Entity.DOMAIN_AXIS,
+          new Event[] {Event.DOUBLE_CLICK}, Button.BUTTON1, null, null));
+      standardGestures.add(new GestureHandlerDef(Handler.AUTO_ZOOM_AXIS, Entity.RANGE_AXIS,
+          new Event[] {Event.DOUBLE_CLICK}, Button.BUTTON1, null, null));
+    }
+    return standardGestures;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/interf/GestureHandlerFactory.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/interf/GestureHandlerFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures.interf;
+
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler;
+import net.sf.mzmine.chartbasics.gestures.standard.DragGestureHandlerDef;
+import net.sf.mzmine.chartbasics.gestures.standard.GestureHandlerDef;
+
+/**
+ * This interface is implemented by, e.g., {@link GestureHandlerDef} and
+ * {@link DragGestureHandlerDef}
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public interface GestureHandlerFactory {
+
+  public ChartGestureHandler createHandler();
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/standard/DragGestureHandlerDef.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/standard/DragGestureHandlerDef.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures.standard;
+
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Button;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Key;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureDragDiffHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureDragDiffHandler.Orientation;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler.DragHandler;
+import net.sf.mzmine.chartbasics.gestures.interf.GestureHandlerFactory;
+
+/**
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+/**
+ * Definition of {@link ChartGestureDragDiffHandler}s Used to store the definition of a drag
+ * difference handler and to generate GestureHandlers
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class DragGestureHandlerDef implements GestureHandlerFactory {
+
+  protected DragHandler[] handler;
+  protected Key[] key;
+  protected Entity entity;
+  protected Button button;
+  protected Orientation orient;
+  protected Object[] param;
+
+  public DragGestureHandlerDef(DragHandler[] handler, Key[] key, Entity entity, Button button,
+      Orientation orient, Object[] param) {
+    super();
+    this.handler = handler;
+    this.key = key;
+    this.entity = entity;
+    this.button = button;
+    this.orient = orient;
+    this.param = param;
+  }
+
+  @Override
+  public ChartGestureHandler createHandler() {
+    return ChartGestureHandler.createDragDiffHandler(handler, key, entity, button, orient, param);
+  }
+
+  public DragHandler[] getHandler() {
+    return handler;
+  }
+
+  public Key[] getKey() {
+    return key;
+  }
+
+  public Entity getEntity() {
+    return entity;
+  }
+
+  public Button getButton() {
+    return button;
+  }
+
+  public Orientation getOrient() {
+    return orient;
+  }
+
+  public Object[] getParam() {
+    return param;
+  }
+
+  public void setHandler(DragHandler[] handler) {
+    this.handler = handler;
+  }
+
+  public void setKey(Key[] key) {
+    this.key = key;
+  }
+
+  public void setEntity(Entity entity) {
+    this.entity = entity;
+  }
+
+  public void setButton(Button button) {
+    this.button = button;
+  }
+
+  public void setOrient(Orientation orient) {
+    this.orient = orient;
+  }
+
+  public void setParam(Object[] param) {
+    this.param = param;
+  }
+
+
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gestures/standard/GestureHandlerDef.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gestures/standard/GestureHandlerDef.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gestures.standard;
+
+import net.sf.mzmine.chartbasics.gestures.ChartGesture;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Button;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Event;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Key;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler.Handler;
+import net.sf.mzmine.chartbasics.gestures.interf.GestureHandlerFactory;
+
+/**
+ * Definition of {@link ChartGestureHandler}s Used to store the definition and to generate
+ * GestureHandlers
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class GestureHandlerDef implements GestureHandlerFactory {
+
+  protected Handler handler;
+  protected Entity entity;
+  protected Event[] event;
+  protected Button button;
+  protected Key key;
+  protected Object[] param;
+
+  public GestureHandlerDef(Handler handler, Entity entity, Event[] event, Button button, Key key,
+      Object[] param) {
+    super();
+    this.handler = handler;
+    this.entity = entity;
+    this.event = event;
+    this.button = button;
+    this.key = key;
+    this.param = param;
+  }
+
+  @Override
+  public ChartGestureHandler createHandler() {
+    return ChartGestureHandler.createHandler(handler, new ChartGesture(entity, event, button, key),
+        param);
+  }
+
+  public Handler getHandler() {
+    return handler;
+  }
+
+  public Entity getEntity() {
+    return entity;
+  }
+
+  public Event[] getEvent() {
+    return event;
+  }
+
+  public Button getButton() {
+    return button;
+  }
+
+  public Key getKey() {
+    return key;
+  }
+
+  public Object[] getParam() {
+    return param;
+  }
+
+  public void setHandler(Handler handler) {
+    this.handler = handler;
+  }
+
+  public void setEntity(Entity entity) {
+    this.entity = entity;
+  }
+
+  public void setEvent(Event[] event) {
+    this.event = event;
+  }
+
+  public void setButton(Button button) {
+    this.button = button;
+  }
+
+  public void setKey(Key key) {
+    this.key = key;
+  }
+
+  public void setParam(Object[] param) {
+    this.param = param;
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/graphicsexport/ChartExportUtil.java
+++ b/src/main/java/io/github/mzmine/chartbasics/graphicsexport/ChartExportUtil.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.graphicsexport;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Paint;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import javax.swing.JMenuItem;
+import org.apache.batik.anim.dom.SVGDOMImplementation;
+import org.apache.batik.svggen.SVGGraphics2D;
+import org.apache.batik.svggen.SVGGraphics2DIOException;
+import org.freehep.graphics2d.VectorGraphics;
+import org.freehep.graphicsio.emf.EMFGraphics2D;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.ChartUtils;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.encoders.EncoderUtil;
+import org.jfree.chart.encoders.ImageFormat;
+import org.jfree.chart.title.PaintScaleLegend;
+import org.jfree.chart.util.Args;
+import org.w3c.dom.DOMImplementation;
+import com.itextpdf.awt.DefaultFontMapper;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.Rectangle;
+import com.itextpdf.text.pdf.PdfContentByte;
+import com.itextpdf.text.pdf.PdfTemplate;
+import com.itextpdf.text.pdf.PdfWriter;
+import net.sf.epsgraphics.ColorMode;
+import net.sf.epsgraphics.EpsGraphics;
+import net.sf.mzmine.chartbasics.ChartLogics;
+import net.sf.mzmine.chartbasics.graphicsexport.GraphicsExportParameters.FixedSize;
+import net.sf.mzmine.util.files.FileAndPathUtil;
+
+/**
+ * Graphics export of JFreeCharts to different vector and pixel graphics formats.
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartExportUtil {
+  // ######################################################################################
+  // VECTORS: PDF uses ITextpdf lib
+
+
+  /**
+   * Add export dialog to popup menu of a chartpanel
+   * 
+   * @param plotChartPanel
+   */
+  public static void addExportDialogToMenu(final ChartPanel cp) {
+    JMenuItem exportGraphics = new JMenuItem("Export graphics...");
+    exportGraphics.addActionListener(e -> GraphicsExportDialog.openDialog(cp.getChart()));
+    // add to menu
+    cp.getPopupMenu().add(exportGraphics);
+  }
+
+
+  /**
+   * takes Only Width in account
+   * 
+   * @param chart
+   * @param sett
+   * @throws Exception
+   */
+  public static void writeChartToImage(ChartPanel chart, GraphicsExportParameters sett)
+      throws Exception {
+    boolean repaint = false;
+    FixedSize fixed = sett.getFixedSize();
+
+    double oldW = sett.getWidthPixel();
+    double oldH = sett.getHeightPixel();
+
+    // Size only by width?
+    if (sett.isUseOnlyWidth()) {
+      // fixed size for chart or plot
+      if (fixed.equals(FixedSize.Chart)) {
+        sett.setHeightPixel(ChartLogics.calcHeightToWidth(chart, oldW, false));
+      } else {
+        // fixed plot width
+        sett.setPixelSize(ChartLogics.calcSizeForPlotWidth(chart, oldW));
+      }
+    } else if (fixed.equals(FixedSize.Plot)) {
+      // fixed plot size - width and height are given
+      sett.setPixelSize(ChartLogics.calcSizeForPlotSize(chart, oldW, oldH));
+    }
+
+    Dimension size = sett.getPixelSize();
+    // resize
+    chart.setPreferredSize(size);
+    chart.setMaximumSize(size);
+    chart.setMinimumSize(size);
+    // repaint
+    if (repaint) {
+      chart.revalidate();
+      chart.repaint();
+    }
+    writeChartToImage(chart.getChart(), sett, chart.getChartRenderingInfo());
+    // reset size
+    sett.setPixelSize(oldW, oldH);
+  }
+
+  /**
+   * This method is used to save all image formats. it uses the specific methods for each file
+   * format
+   * 
+   * @param chart
+   * @param sett
+   * @param chartRenderingInfo
+   */
+  private static void writeChartToImage(JFreeChart chart, GraphicsExportParameters sett,
+      ChartRenderingInfo info) throws Exception {
+    // Background color
+    Paint saved = chart.getBackgroundPaint();
+    chart.setBackgroundPaint(sett.getColorWithAlpha());
+    chart.setBackgroundImageAlpha((float) sett.getTransparency());
+    if (chart.getLegend() != null)
+      chart.getLegend().setBackgroundPaint(sett.getColorWithAlpha());
+    // legends and stuff
+    for (int i = 0; i < chart.getSubtitleCount(); i++)
+      if (PaintScaleLegend.class.isAssignableFrom(chart.getSubtitle(i).getClass()))
+        ((PaintScaleLegend) chart.getSubtitle(i)).setBackgroundPaint(sett.getColorWithAlpha());
+
+    // apply bg
+    chart.getPlot().setBackgroundPaint(sett.getColorWithAlpha());
+
+    // create folder
+    File f = sett.getFullpath();
+    if (!f.exists()) {
+      if (f.getParentFile() != null)
+        f.getParentFile().mkdirs();
+      // f.createNewFile();
+    }
+
+    Dimension size = sett.getPixelSize();
+    // Format
+    switch (sett.getFormat()) {
+      case "PDF":
+        writeChartToPDF(chart, size.width, size.height, f);
+        break;
+      case "PNG":
+        writeChartToPNG(chart, info, size.width, size.height, f, (int) sett.getDPI());
+        break;
+      case "JPG":
+        writeChartToJPEG(chart, info, size.width, size.height, f, (int) sett.getDPI());
+        break;
+      case "EPS":
+        writeChartToEPS(chart, size.width, size.height, f);
+        break;
+      case "SVG":
+        writeChartToSVG(chart, size.width, size.height, f);
+        break;
+      case "EMF":
+        writeChartToEMF(chart, size.width, size.height, f);
+        break;
+    }
+    //
+    chart.setBackgroundPaint(saved);
+    chart.setBackgroundImageAlpha(255);
+    if (chart.getLegend() != null)
+      chart.getLegend().setBackgroundPaint(saved);
+    // legends and stuff
+    for (int i = 0; i < chart.getSubtitleCount(); i++)
+      if (PaintScaleLegend.class.isAssignableFrom(chart.getSubtitle(i).getClass()))
+        ((PaintScaleLegend) chart.getSubtitle(i)).setBackgroundPaint(saved);
+
+    // apply bg
+    chart.getPlot().setBackgroundPaint(saved);
+  }
+
+  /**
+   * This method saves a chart as a PDF with given dimensions
+   * 
+   * @param chart
+   * @param width
+   * @param height
+   * @param fileName is a full path
+   */
+  public static void writeChartToPDF(JFreeChart chart, int width, int height, File fileName)
+      throws Exception {
+    PdfWriter writer = null;
+
+    Document document = new Document(new Rectangle(width, height));
+
+    try {
+      writer = PdfWriter.getInstance(document, new FileOutputStream(fileName));
+      document.open();
+      PdfContentByte contentByte = writer.getDirectContent();
+      PdfTemplate template = contentByte.createTemplate(width, height);
+      Graphics2D graphics2d = template.createGraphics(width, height, new DefaultFontMapper());
+      Rectangle2D rectangle2d = new Rectangle2D.Double(0, 0, width, height);
+
+      chart.draw(graphics2d, rectangle2d);
+
+      graphics2d.dispose();
+      contentByte.addTemplate(template, 0, 0);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw e;
+    } finally {
+      document.close();
+    }
+  }
+
+  public static void writeChartToPDF(JFreeChart chart, int width, int height, File path,
+      String fileName) throws Exception {
+    writeChartToPDF(chart, width, height, FileAndPathUtil.getRealFilePath(path, fileName, ".pdf"));
+  }
+
+  // ######################################################################################
+  // PIXELS: JPG PNG
+  public static void writeChartToPNG(JFreeChart chart, ChartRenderingInfo info, int width,
+      int height, File fileName) throws IOException {
+    ChartUtils.saveChartAsPNG(fileName, chart, width, height, info);
+  }
+
+  public static void writeChartToPNG(JFreeChart chart, ChartRenderingInfo info, int width,
+      int height, File fileName, int resolution) throws IOException {
+    if (resolution == 72)
+      writeChartToPNG(chart, info, width, height, fileName);
+    else {
+      OutputStream out = new BufferedOutputStream(new FileOutputStream(fileName));
+      try {
+        BufferedImage image = paintScaledChartToBufferedImage(chart, info, out, width, height,
+            resolution, BufferedImage.TYPE_INT_ARGB);
+        out.write(ChartUtils.encodeAsPNG(image));
+      } finally {
+        out.close();
+      }
+    }
+  }
+
+  public static void writeChartToJPEG(JFreeChart chart, int width, int height, File fileName)
+      throws IOException {
+    ChartUtils.saveChartAsJPEG(fileName, chart, width, height);
+  }
+
+  public static void writeChartToJPEG(JFreeChart chart, ChartRenderingInfo info, int width,
+      int height, File fileName, int resolution) throws IOException {
+    // Background color
+    Paint saved = chart.getBackgroundPaint();
+    if (((Color) saved).getAlpha() == 0) {
+      chart.setBackgroundPaint(Color.WHITE);
+      chart.setBackgroundImageAlpha(255);
+      if (chart.getLegend() != null)
+        chart.getLegend().setBackgroundPaint(Color.WHITE);
+      // legends and stuff
+      for (int i = 0; i < chart.getSubtitleCount(); i++)
+        if (PaintScaleLegend.class.isAssignableFrom(chart.getSubtitle(i).getClass()))
+          ((PaintScaleLegend) chart.getSubtitle(i)).setBackgroundPaint(Color.WHITE);
+
+      // apply bg
+      chart.getPlot().setBackgroundPaint(Color.WHITE);
+    }
+    //
+    if (resolution == 72)
+      writeChartToJPEG(chart, width, height, fileName);
+    else {
+      OutputStream out = new BufferedOutputStream(new FileOutputStream(fileName));
+      try {
+        BufferedImage image = paintScaledChartToBufferedImage(chart, info, out, width, height,
+            resolution, BufferedImage.TYPE_INT_RGB);
+        EncoderUtil.writeBufferedImage(image, ImageFormat.JPEG, out, 1.f);
+      } finally {
+        out.close();
+      }
+    }
+  }
+
+
+  /**
+   * Paints a chart with scaling options
+   * 
+   * @param chart
+   * @param info
+   * @param out
+   * @param width
+   * @param height
+   * @param resolution
+   * @return BufferedImage of a given chart with scaling to resolution
+   * @throws IOException
+   */
+  private static BufferedImage paintScaledChartToBufferedImage(JFreeChart chart,
+      ChartRenderingInfo info, OutputStream out, int width, int height, int resolution,
+      int bufferedIType) throws IOException {
+    Args.nullNotPermitted(out, "out");
+    Args.nullNotPermitted(chart, "chart");
+
+    double scaleX = resolution / 72.0;
+    double scaleY = resolution / 72.0;
+
+    double desiredWidth = width * scaleX;
+    double desiredHeight = height * scaleY;
+    double defaultWidth = width;
+    double defaultHeight = height;
+    boolean scale = false;
+
+    // get desired width and height from somewhere then...
+    if ((scaleX != 1) || (scaleY != 1)) {
+      scale = true;
+    }
+
+    BufferedImage image = new BufferedImage((int) desiredWidth, (int) desiredHeight, bufferedIType);
+    Graphics2D g2 = image.createGraphics();
+
+    if (scale) {
+      AffineTransform saved = g2.getTransform();
+      g2.transform(AffineTransform.getScaleInstance(scaleX, scaleY));
+      chart.draw(g2, new Rectangle2D.Double(0, 0, defaultWidth, defaultHeight), info);
+      g2.setTransform(saved);
+      g2.dispose();
+    } else {
+      chart.draw(g2, new Rectangle2D.Double(0, 0, defaultWidth, defaultHeight), info);
+    }
+    return image;
+  }
+
+  // ######################################################################################
+  // VECTORS: EPS uses EpsGraphics2D
+  // SVG uses BATIK lib
+  public static void writeChartToSVG(JFreeChart chart, int width, int height, File name)
+      throws Exception {
+    // Get a DOMImplementation
+    DOMImplementation domImpl = SVGDOMImplementation.getDOMImplementation();
+    org.w3c.dom.Document document = domImpl.createDocument(null, "svg", null);
+    SVGGraphics2D svgGenerator = new SVGGraphics2D(document);
+    svgGenerator.setSVGCanvasSize(new Dimension(width, height));
+    chart.draw(svgGenerator, new Rectangle2D.Double(0, 0, width, height));
+
+
+    boolean useCSS = true; // we want to use CSS style attribute
+
+    Writer out = null;
+    try {
+      out = new OutputStreamWriter(new FileOutputStream(name), "UTF-8");
+      svgGenerator.stream(out, useCSS);
+    } catch (UnsupportedEncodingException | FileNotFoundException e) {
+      e.printStackTrace();
+      throw e;
+    } catch (SVGGraphics2DIOException e) {
+      e.printStackTrace();
+      throw e;
+    } finally {
+      try {
+        out.close();
+      } catch (Exception e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+        throw e;
+      }
+    }
+  }
+
+
+  public static void writeChartToEPS(JFreeChart chart, int width, int height, File name)
+      throws IOException {
+    EpsGraphics g;
+    try {
+      g = new EpsGraphics("EpsTools Drawable Export", new FileOutputStream(name), 0, 0, width,
+          height, ColorMode.COLOR_RGB);
+      Rectangle2D rectangle2d = new Rectangle2D.Double(0, 0, width, height);
+      chart.draw((Graphics2D) g, rectangle2d);
+      g.close();
+    } catch (IOException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+      throw e;
+    }
+  }
+
+
+  public static void writeChartToEMF(JFreeChart chart, int width, int height, File name)
+      throws IOException {
+    try {
+      VectorGraphics g = new EMFGraphics2D(name, new Dimension(width, height));
+      g.startExport();
+      Rectangle2D rectangle2d = new Rectangle2D.Double(0, 0, width, height);
+      chart.draw((Graphics2D) g, rectangle2d);
+      g.endExport();
+    } catch (IOException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+      throw e;
+    }
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/graphicsexport/GraphicsExportDialog.java
+++ b/src/main/java/io/github/mzmine/chartbasics/graphicsexport/GraphicsExportDialog.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.graphicsexport;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.IntStream;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.border.EmptyBorder;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import net.miginfocom.swing.MigLayout;
+import net.sf.mzmine.chartbasics.ChartLogics;
+import net.sf.mzmine.chartbasics.chartthemes.ChartThemeFactory;
+import net.sf.mzmine.chartbasics.chartthemes.ChartThemeParameters;
+import net.sf.mzmine.chartbasics.chartthemes.EStandardChartTheme;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+import net.sf.mzmine.framework.fontspecs.FontSpecs;
+import net.sf.mzmine.framework.fontspecs.JFontSpecs;
+import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.UserParameter;
+import net.sf.mzmine.parameters.parametertypes.ComboComponent;
+import net.sf.mzmine.parameters.parametertypes.DoubleComponent;
+import net.sf.mzmine.parameters.parametertypes.DoubleParameter;
+import net.sf.mzmine.parameters.parametertypes.FontParameter;
+import net.sf.mzmine.parameters.parametertypes.OptionalParameterComponent;
+import net.sf.mzmine.parameters.parametertypes.StringComponent;
+import net.sf.mzmine.parameters.parametertypes.StringParameter;
+import net.sf.mzmine.util.DialogLoggerUtil;
+import net.sf.mzmine.util.components.GridBagPanel;
+import net.sf.mzmine.util.files.FileAndPathUtil;
+import net.sf.mzmine.util.files.FileTypeFilter;
+
+/**
+ * A graphics export dialog with preview and a panel for {@link GraphicsExportParameters} and
+ * {@link ChartThemeParameters} to set teh chart theme previous to export
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class GraphicsExportDialog extends JFrame {
+  private static final long serialVersionUID = 1L;
+
+  private final Logger LOG = Logger.getLogger(this.getClass().getName());
+  // only one instance!
+  private static GraphicsExportDialog inst;
+  // theme
+  private EStandardChartTheme theme = ChartThemeFactory.createBlackNWhiteTheme();
+  // chooser
+  private JFileChooser chooser = new JFileChooser();
+  // parameters
+  private GraphicsExportParameters parameters;
+  private ChartThemeParameters chartParam;
+  // map all components and parameter names
+  private final Map<String, JComponent> parametersAndComponents;
+
+  protected final JPanel contentPanel = new JPanel();
+  private JButton btnPath;
+  private JButton btnRenewPreview;
+  private JButton btnApply;
+  private boolean listenersEnabled = true;
+
+  // ###################################################################
+  // Vars
+  protected ChartPanel chartPanel;
+  private JPanel pnChartPreview;
+
+  /**
+   * Launch the application.
+   */
+  public static void main(String[] args) {
+    try {
+      XYSeries s = new XYSeries("1");
+      IntStream.range(0, 10).forEach(i -> s.add(i, i));
+      XYSeriesCollection data = new XYSeriesCollection(s);
+      JFreeChart chart = ChartFactory.createXYLineChart("XY", "time (s)", "intensity", data);
+      GraphicsExportDialog.createInstance();
+      GraphicsExportDialog.openDialog(chart);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Create the dialog.
+   */
+  public GraphicsExportDialog() {
+    final JFrame thisframe = this;
+    //
+    parameters = new GraphicsExportParameters();
+    chartParam = new ChartThemeParameters();
+    parametersAndComponents = new HashMap<String, JComponent>();
+
+    String[] formats = parameters.getParameter(GraphicsExportParameters.exportFormat).getChoices();
+    chooser.addChoosableFileFilter(new FileTypeFilter(formats, "Export images"));
+    chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+    //
+    setBounds(100, 100, 808, 795);
+    getContentPane().setLayout(new BorderLayout());
+    contentPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
+    getContentPane().add(contentPanel, BorderLayout.CENTER);
+    contentPanel.setLayout(new MigLayout("", "[][][grow]", "[][][][grow]"));
+    {
+      StringParameter p = parameters.getParameter(GraphicsExportParameters.path);
+      StringComponent txtPath = p.createEditingComponent();
+      contentPanel.add(txtPath, "flowx,cell 0 0,growx");
+      parametersAndComponents.put(p.getName(), txtPath);
+    }
+    {
+      btnPath = new JButton("Path");
+      btnPath.addActionListener(new ActionListener() {
+        public void actionPerformed(ActionEvent e) {
+          choosePath();
+        }
+      });
+      contentPanel.add(btnPath, "cell 1 0");
+    }
+    {
+      StringParameter p = parameters.getParameter(GraphicsExportParameters.filename);
+      StringComponent txtFileName = p.createEditingComponent();
+      contentPanel.add(txtFileName, "cell 0 1,growx");
+      parametersAndComponents.put(p.getName(), txtFileName);
+    }
+    {
+      JLabel lblFilename = new JLabel("filename");
+      contentPanel.add(lblFilename, "cell 1 1");
+    }
+    {
+      JPanel pnSettingsLeft = new JPanel();
+      pnSettingsLeft.setMinimumSize(new Dimension(260, 260));
+      contentPanel.add(pnSettingsLeft, "cell 0 3,grow");
+      pnSettingsLeft.setLayout(new BorderLayout(0, 0));
+      {
+
+        GridBagPanel pn = new GridBagPanel();
+        {
+          // add unit
+          UserParameter p;
+          JComponent comp;
+          // add unit
+          p = (UserParameter) parameters.getParameter(GraphicsExportParameters.unit);
+          comp = p.createEditingComponent();
+          comp.setToolTipText(p.getDescription());
+          comp.setEnabled(true);
+          pn.add(comp, 2, 2);
+          parametersAndComponents.put(p.getName(), comp);
+
+          int i = 0;
+          // add export settings
+          Parameter[] param = parameters.getParameters();
+          for (int pi = 3; pi < param.length; pi++) {
+            p = (UserParameter) param[pi];
+            comp = p.createEditingComponent();
+            comp.setToolTipText(p.getDescription());
+            comp.setEnabled(true);
+            pn.add(new JLabel(p.getName()), 0, i);
+            pn.add(comp, 1, i, 1, 1, 1, 1);
+            // add to map
+            parametersAndComponents.put(p.getName(), comp);
+            i++;
+          }
+
+          // add separator
+          pn.add(new JSeparator(), 0, i, 5, 1, 1, 1, GridBagConstraints.BOTH);
+          i++;
+          // add Apply theme button
+          JButton btnApply2 = new JButton("Apply theme");
+          btnApply2.addActionListener(e -> applyTheme());
+          pn.add(btnApply2, 0, i, 5, 1, 1, 1, GridBagConstraints.BOTH);
+          i++;
+
+          // add chart settings
+          param = chartParam.getParameters();
+          for (int pi = 0; pi < param.length; pi++) {
+            p = (UserParameter) param[pi];
+            comp = p.createEditingComponent();
+            comp.setToolTipText(p.getDescription());
+            comp.setEnabled(true);
+            pn.add(new JLabel(p.getName()), 0, i);
+            pn.add(comp, 1, i, 4, 1);
+            // add to map
+            parametersAndComponents.put(p.getName(), comp);
+            i++;
+          }
+
+          // add listener to master font
+          JFontSpecs master = (JFontSpecs) parametersAndComponents
+              .get(chartParam.getParameter(ChartThemeParameters.masterFont).getName());
+          master.addListener(fspec -> {
+            if (listenersEnabled)
+              handleMasterFontChanged(fspec);
+          });
+        }
+
+        JScrollPane scrollPane = new JScrollPane(pn);
+        scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+        pnSettingsLeft.add(scrollPane, BorderLayout.CENTER);
+        scrollPane.getVerticalScrollBar().setUnitIncrement(18);
+        scrollPane.revalidate();
+        scrollPane.repaint();
+      }
+    }
+    {
+      {
+        pnChartPreview = new JPanel();
+        pnChartPreview.setLayout(null);
+        contentPanel.add(pnChartPreview, "cell 1 3 2 1,grow");
+      }
+    }
+    {
+      JPanel buttonPane = new JPanel();
+      buttonPane.setLayout(new FlowLayout(FlowLayout.RIGHT));
+      getContentPane().add(buttonPane, BorderLayout.SOUTH);
+      {
+        JButton okButton = new JButton("Save");
+        okButton.addActionListener(e -> saveGraphicsAs());
+        okButton.setActionCommand("OK");
+        buttonPane.add(okButton);
+        getRootPane().setDefaultButton(okButton);
+      }
+      {
+        btnRenewPreview = new JButton("Renew Preview");
+        btnRenewPreview.addActionListener(e -> renewPreview());
+        buttonPane.add(btnRenewPreview);
+      }
+      {
+        btnApply = new JButton("Apply theme");
+        btnApply.addActionListener(e -> applyTheme());
+        buttonPane.add(btnApply);
+      }
+      {
+        JButton cancelButton = new JButton("Cancel");
+        cancelButton.addActionListener(e -> setVisible(false));
+        cancelButton.setActionCommand("Cancel");
+        buttonPane.add(cancelButton);
+      }
+    }
+    // set all to components
+    updateComponentsFromParameters();
+  }
+
+
+  // ###################################################################
+  // create instance in window and imageeditor
+  public static GraphicsExportDialog createInstance() {
+    if (inst == null) {
+      inst = new GraphicsExportDialog();
+    }
+    return inst;
+  }
+
+  public static GraphicsExportDialog getInst() {
+    if (inst == null)
+      return createInstance();
+    return inst;
+  }
+
+  // ###################################################################
+  // get Settings
+  /**
+   * Open Dialog with chart
+   * 
+   * @param chart
+   */
+  public static void openDialog(JFreeChart chart) {
+    createInstance().openDialogI(chart);
+  }
+
+  protected void openDialogI(JFreeChart chart) {
+    try {
+      // create new chart to decouple from original chart
+      JFreeChart copy = chart;
+      try {
+        copy = (JFreeChart) chart.clone();
+      } catch (Exception e) {
+        LOG.log(Level.WARNING, "Chart cannot be cloned", e);
+      }
+      addChartToPanel(new EChartPanel(copy), true);
+      setVisible(true);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+
+  protected void addChartToPanel(ChartPanel chart, boolean renew) {
+    //
+    chartPanel = chart;
+    getPnChartPreview().removeAll();
+    getPnChartPreview().add(chartPanel);
+    if (renew)
+      renewPreview();
+  }
+
+
+  /**
+   * Applies the theme defined as ChartParameters
+   */
+  protected void applyTheme() {
+    // update param
+    updateParameterSetFromComponents();
+    // apply settings
+    chartParam.applyToChartTheme(theme);
+    chartParam.applyToChart(chartPanel.getChart());
+    theme.apply(chartPanel.getChart());
+    // renewPreview();
+  }
+
+  /**
+   * renew chart preview with specified size
+   */
+  protected void renewPreview() {
+    // set dimensions to chartpanel
+    try {
+      // update param
+      updateParameterSetFromComponents();
+
+      //
+      if (parameters.isUseOnlyWidth()) {
+        double height =
+            (ChartLogics.calcHeightToWidth(chartPanel, parameters.getWidthPixel(), false));
+
+        DoubleParameter p =
+            parameters.getParameter(GraphicsExportParameters.height).getEmbeddedParameter();
+        DoubleComponent c =
+            ((OptionalParameterComponent<DoubleComponent>) parametersAndComponents.get(p.getName()))
+                .getEmbeddedComponent();
+        p.setValueToComponent(c, height);
+        p.setValueFromComponent(c);
+
+        chartPanel.setSize((int) parameters.getWidthPixel(), (int) parameters.getHeightPixel());
+        getPnChartPreview().repaint();
+      } else {
+        chartPanel.setSize((int) parameters.getWidthPixel(), (int) parameters.getHeightPixel());
+        chartPanel.repaint();
+      }
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      LOG.log(Level.SEVERE, "Error while renewing preview of graphics export dialog ", ex);
+    }
+  }
+
+  /**
+   * choose a path by file chooser
+   */
+  protected void choosePath() {
+    // open filechooser
+    if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+      File file = chooser.getSelectedFile();
+      //
+      StringComponent txtPath =
+          (StringComponent) parametersAndComponents.get(GraphicsExportParameters.path.getName());
+      StringComponent txtName = (StringComponent) parametersAndComponents
+          .get(GraphicsExportParameters.filename.getName());
+      ComboComponent<String> format = (ComboComponent<String>) parametersAndComponents
+          .get(GraphicsExportParameters.exportFormat.getName());
+      // only a folder? or also a file name > then split
+      if (file.isDirectory()) {
+        // only a folder
+        txtPath.setText(file.getAbsolutePath());
+      } else {
+        // data file selected
+        // get folder
+        txtPath.setText(FileAndPathUtil.getFolderOfFile(file).getAbsolutePath());
+        // get filename
+        txtName.setText(FileAndPathUtil.getFileNameFromPath(file));
+        // get format without .
+        String f = FileAndPathUtil.getFormat(file).toUpperCase();
+        format.setSelectedItem(f);
+      }
+    }
+  }
+
+  protected void saveGraphicsAs() {
+    updateParameterSetFromComponents();
+    //
+    if (parameters.checkParameterValues(null)) {
+      File path = parameters.getFullpath();
+      try {
+        LOG.info("Writing image to file: " + path.getAbsolutePath());
+        ChartExportUtil.writeChartToImage(chartPanel, parameters);
+        LOG.info("Success" + path);
+      } catch (Exception e) {
+        e.printStackTrace();
+        LOG.log(Level.SEVERE, "File not written (" + path + ")", e);
+        DialogLoggerUtil.showErrorDialog(this, "File not written. ", e);
+      }
+    }
+  }
+
+  /**
+   * changes the components of all fonts to the master font
+   * 
+   * @param font
+   */
+  private void handleMasterFontChanged(FontSpecs font) {
+    String master = ChartThemeParameters.masterFont.getName();
+    for (Parameter<?> p : chartParam.getParameters()) {
+      if (!(p instanceof FontParameter) || master.equals(p.getName()))
+        continue;
+      FontParameter up = (FontParameter) p;
+      JFontSpecs component = (JFontSpecs) parametersAndComponents.get(p.getName());
+      up.setValueToComponent(component, font);
+    }
+  }
+
+  /**
+   * 
+   * @param p
+   * @return
+   */
+  public JComponent getComponentForParameter(Parameter<?> p) {
+    return parametersAndComponents.get(p.getName());
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected void updateParameterSetFromComponents() {
+    for (Parameter<?> p : parameters.getParameters()) {
+      if (!(p instanceof UserParameter))
+        continue;
+      UserParameter up = (UserParameter) p;
+      JComponent component = parametersAndComponents.get(p.getName());
+      up.setValueFromComponent(component);
+    }
+
+    for (Parameter<?> p : chartParam.getParameters()) {
+      if (!(p instanceof UserParameter))
+        continue;
+      UserParameter up = (UserParameter) p;
+      JComponent component = parametersAndComponents.get(p.getName());
+      up.setValueFromComponent(component);
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected void updateComponentsFromParameters() {
+    for (Parameter<?> p : parameters.getParameters()) {
+      if (!(p instanceof UserParameter))
+        continue;
+      UserParameter up = (UserParameter) p;
+      JComponent component = parametersAndComponents.get(p.getName());
+      up.setValueToComponent(component, up.getValue());
+    }
+
+    for (Parameter<?> p : chartParam.getParameters()) {
+      if (!(p instanceof UserParameter))
+        continue;
+      UserParameter up = (UserParameter) p;
+      JComponent component = parametersAndComponents.get(p.getName());
+      if (component instanceof JFontSpecs) {
+        // stop listeners from changing all fonts to master
+        JFontSpecs f = (JFontSpecs) component;
+        setListenersEnabled(false);
+        up.setValueToComponent(f, up.getValue());
+        f.stopListener();
+        setListenersEnabled(true);
+      } else
+        up.setValueToComponent(component, up.getValue());
+    }
+  }
+
+  private void setListenersEnabled(boolean state) {
+    listenersEnabled = state;
+  }
+
+  public JPanel getPnChartPreview() {
+    return pnChartPreview;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/graphicsexport/GraphicsExportParameters.java
+++ b/src/main/java/io/github/mzmine/chartbasics/graphicsexport/GraphicsExportParameters.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.graphicsexport;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.io.File;
+import java.text.DecimalFormat;
+import net.sf.mzmine.parameters.Parameter;
+import net.sf.mzmine.parameters.impl.SimpleParameterSet;
+import net.sf.mzmine.parameters.parametertypes.ColorParameter;
+import net.sf.mzmine.parameters.parametertypes.ComboParameter;
+import net.sf.mzmine.parameters.parametertypes.DoubleParameter;
+import net.sf.mzmine.parameters.parametertypes.OptionalParameter;
+import net.sf.mzmine.parameters.parametertypes.StringParameter;
+import net.sf.mzmine.util.DimensionUnitUtil;
+import net.sf.mzmine.util.DimensionUnitUtil.DimUnit;
+import net.sf.mzmine.util.files.FileAndPathUtil;
+
+public class GraphicsExportParameters extends SimpleParameterSet {
+
+  public enum FixedSize {
+    Chart, Plot;
+  }
+
+  public static final StringParameter path = new StringParameter("Path", "The file path");
+  public static final StringParameter filename = new StringParameter("Filename", "The file name");
+
+  public static final DoubleParameter width = new DoubleParameter("Width",
+      "Uses fixed width for the chart or plot", DecimalFormat.getInstance(), 15.0);
+
+  public static final DoubleParameter dpi = new DoubleParameter("Resolution (dpi)",
+      "dots per inch resolution (for print usually 300 up to 600 dpi)", DecimalFormat.getInstance(),
+      300.0);
+
+  public static final OptionalParameter<DoubleParameter> height =
+      new OptionalParameter<DoubleParameter>(new DoubleParameter("Height",
+          "Only uses width if height is unchecked. Otherwise uses fixed height for the chart or plot",
+          DecimalFormat.getInstance(), 8.0));
+
+  public static final ComboParameter<String> exportFormat = new ComboParameter<String>("Format",
+      "The image export format", new String[] {"PDF", "EMF", "EPS", "SVG", "JPG", "PNG"}, "PNG");
+
+  public static final ComboParameter<FixedSize> fixedSize =
+      new ComboParameter<FixedSize>("Fixed size for",
+          "Fixed size for the plot (the data space without axes and titles) or the whole chart.",
+          FixedSize.values(), FixedSize.Chart);
+
+  public static final ColorParameter color =
+      new ColorParameter("Background", "Background color", Color.WHITE);
+  public static final DoubleParameter alpha = new DoubleParameter("Transparency",
+      "Transparency from 0.0-1.0 (fully visible)", DecimalFormat.getInstance(), 1.0, 0.0, 1.0);
+
+  public static final ComboParameter<DimUnit> unit = new ComboParameter<>("Unit",
+      "Unit for width and height dimensions", DimUnit.values(), DimUnit.CM);
+
+  public GraphicsExportParameters() {
+    super(new Parameter[] {path, filename, unit, exportFormat, fixedSize, width, height, dpi, color,
+        alpha});
+    height.setValue(true);
+  }
+
+  /**
+   * height is unchecked - use only width for size calculations
+   * 
+   * @return
+   */
+  public boolean isUseOnlyWidth() {
+    return !this.getParameter(height).getValue();
+  }
+
+  public FixedSize getFixedSize() {
+    return this.getParameter(fixedSize).getValue();
+  }
+
+  /**
+   * height in unit
+   * 
+   * @return
+   */
+  public double getHeight() {
+    return this.getParameter(height).getEmbeddedParameter().getValue();
+  }
+
+  /**
+   * width in unit
+   * 
+   * @return
+   */
+  public double getWidth() {
+    return this.getParameter(width).getValue();
+  }
+
+  /**
+   * Pixel size
+   * 
+   * @return
+   */
+  public Dimension getPixelSize() {
+    return new Dimension((int) getWidthPixel(), (int) getHeightPixel());
+  }
+
+  /**
+   * Pixel width
+   * 
+   * @return
+   */
+  public float getWidthPixel() {
+    return DimensionUnitUtil.toPixel((float) getWidth(), getUnit());
+  }
+
+  /**
+   * Pixel height
+   * 
+   * @return
+   */
+  public float getHeightPixel() {
+    return DimensionUnitUtil.toPixel((float) getHeight(), getUnit());
+  }
+
+  public double getDPI() {
+    return this.getParameter(dpi).getValue();
+  }
+
+  public Color getColor() {
+    return this.getParameter(color).getValue();
+  }
+
+  public Color getColorWithAlpha() {
+    Color c = getColor();
+    return new Color(c.getRed(), c.getGreen(), c.getBlue(), (int) (255 * getTransparency()));
+  }
+
+  public DimUnit getUnit() {
+    return this.getParameter(unit).getValue();
+  }
+
+  public String getFormat() {
+    return this.getParameter(exportFormat).getValue();
+  }
+
+  public double getTransparency() {
+    return this.getParameter(alpha).getValue();
+  }
+
+  // file
+  public String getPath() {
+    return this.getParameter(path).getValue();
+  }
+
+  public File getPathAsFile() {
+    return new File(this.getParameter(path).getValue());
+  }
+
+  public String getFilename() {
+    return this.getParameter(filename).getValue();
+  }
+
+  /**
+   * path/filename.format
+   * 
+   * @return
+   */
+  public File getFullpath() {
+    return FileAndPathUtil.getRealFilePath(getPathAsFile(), getFilename(), getFormat());
+  }
+
+  /**
+   * Converts the pixel value to the specified unit
+   * 
+   * @param value as pixel
+   */
+  public void setWidthPixel(double value) {
+    this.getParameter(width).setValue(DimensionUnitUtil.pixelToUnit(value, getUnit()));
+  }
+
+  /**
+   * Converts the pixel value to the specified unit
+   * 
+   * @param value as pixel
+   */
+  public void setHeightPixel(double value) {
+    this.getParameter(height).getEmbeddedParameter()
+        .setValue(DimensionUnitUtil.pixelToUnit(value, getUnit()));
+  }
+
+  /**
+   * Converts the pixel value to the specified unit
+   * 
+   * @param value as pixel
+   */
+  public void setPixelSize(Dimension size) {
+    setWidthPixel(size.getWidth());
+    setHeightPixel(size.getHeight());
+  }
+
+  /**
+   * Converts the pixel value to the specified unit
+   * 
+   * @param value as pixel
+   */
+  public void setPixelSize(double w, double h) {
+    setWidthPixel(w);
+    setHeightPixel(h);
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/javafx/ChartGestureMouseAdapterFX.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/javafx/ChartGestureMouseAdapterFX.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.javafx;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.entity.EntityCollection;
+import org.jfree.chart.fx.ChartCanvas;
+import org.jfree.chart.fx.ChartViewer;
+import org.jfree.chart.fx.interaction.MouseHandlerFX;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.ScrollEvent;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Button;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Event;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Key;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureDragDiffHandler.Orientation;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureEvent;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler.DragHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler.Handler;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+import net.sf.mzmine.chartbasics.gui.wrapper.MouseEventWrapper;
+
+/**
+ * Handles drag zooming of charts on a {@link ChartCanvas}. This handler should be configured with
+ * the required modifier keys and installed as a live handler (not an auxiliary handler). This
+ * handler only works for a <b>ChartCanvas</b> that is embedded in a {@link ChartViewer}, since it
+ * relies on the <b>ChartViewer</b> for drawing the zoom rectangle.
+ */
+public class ChartGestureMouseAdapterFX implements MouseHandlerFX {
+
+  private ChartViewer chartViewer;
+  private ChartViewWrapper cw;
+  private int lastEntityX = -1, lastEntityY = -1;
+  private ChartEntity lastEntity = null;
+  private ChartGestureEvent lastDragEvent = null;
+
+  // handle gestures
+  private List<ChartGestureHandler> gestureHandlers;
+  // listen for
+  private EnumMap<Event, Boolean> listensFor = new EnumMap<Event, Boolean>(Event.class);
+  //
+  private String id;
+  private boolean isEnabled = true;
+
+  /**
+   * Creates a new instance with no modifier keys required.
+   * 
+   * @param id the handler ID ({@code null} not permitted).
+   * @param parent the chart viewer.
+   */
+  public ChartGestureMouseAdapterFX(String id, ChartViewer chartViewer) {
+    this.id = id;
+    this.chartViewer = chartViewer;
+    cw = new ChartViewWrapper(chartViewer);
+  }
+
+  @Override
+  public boolean hasMatchingModifiers(MouseEvent e) {
+    return true;
+  }
+
+  @Override
+  public String getID() {
+    return id;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return isEnabled;
+  }
+
+  public void setEnabled(boolean isEnabled) {
+    this.isEnabled = isEnabled;
+  }
+
+  /**
+   * True if Event.ALL or e was added as part of a gesture handler
+   * 
+   * @param e
+   * @return
+   */
+  private boolean listensFor(Event e) {
+    return listensFor.get(Event.ALL) || listensFor.get(e);
+  }
+
+  /**
+   * Call all handlers for a specific Gesture Also call all parent handlers (AXIS is parent entity
+   * of RANGE_AXIS entity ALL is parent of all events/entities)
+   * 
+   * @param e
+   */
+  private void handleEvent(final ChartGestureEvent e) {
+    if (gestureHandlers != null)
+      gestureHandlers.stream().filter(handler -> handler.getGesture().filter(e.getGesture()))
+          .forEach(handler -> {
+        	  handler.accept(e);  
+          });
+  }
+
+  /**
+   * Add drag handlers for each key (key and handler have to be ordered)
+   * 
+   * @param g
+   * @param handler
+   */
+  public void addDragGestureHandler(DragHandler[] handler, Key[] key, Entity entity, Button button,
+      Orientation orient, Object[] param) {
+    ChartGestureHandler h =
+        ChartGestureHandler.createDragDiffHandler(handler, key, entity, button, orient, param);
+    addGestureHandler(h);
+  }
+
+  /**
+   * Add a preset handler for specific gestures and ChartMouseGestureEvents
+   * 
+   * @param g
+   * @param handler
+   */
+  public void addGestureHandler(Handler handler, Entity entity, Event[] event, Button button,
+      Key key, Object[] param) {
+    ChartGestureHandler h = ChartGestureHandler.createHandler(handler,
+        new ChartGesture(entity, event, button, key), param);
+    addGestureHandler(h);
+  }
+
+  /**
+   * Add a handler for specific gestures and ChartMouseGestureEvents
+   * 
+   * @param g
+   * @param handler
+   */
+  public void addGestureHandler(ChartGestureHandler handler) {
+    if (gestureHandlers == null) {
+      gestureHandlers = new ArrayList<ChartGestureHandler>();
+      for (Event e : Event.values())
+        listensFor.put(e, false);
+    }
+
+    gestureHandlers.add(handler);
+    for (Event e : handler.getGesture().getEvent())
+      listensFor.replace(e, true);
+  }
+
+  /**
+   * Add a handler for specific gestures and ChartMouseGestureEvents
+   * 
+   * @param g
+   * @param handler
+   */
+  public void removeGestureHandler(ChartGestureHandler handler) {
+    if (gestureHandlers == null)
+      return;
+
+    if (gestureHandlers.remove(handler)) {
+      // reset listenFor
+      for (Event e : Event.values())
+        listensFor.replace(e, false);
+
+      // set all again
+      for (ChartGestureHandler gh : gestureHandlers)
+        for (Event e : gh.getGesture().getEvent())
+          listensFor.replace(e, true);
+    }
+  }
+
+  /**
+   * Find chartentities like JFreeChartEntity, AxisEntity, PlotEntity, TitleEntity, XY...
+   * 
+   * @param chartPanel
+   * @param x
+   * @param y
+   * @return
+   */
+  private ChartEntity findChartEntity(MouseEventWrapper e) {
+    // TODO check if insets were needed
+    // coordinates to find chart entities
+    int x = (int) ((e.getX()) / chartViewer.getCanvas().getScaleX());
+    int y = (int) ((e.getY()) / chartViewer.getCanvas().getScaleY());
+
+    if (lastEntity != null && x == lastEntityX && y == lastEntityY)
+      return lastEntity;
+    else {
+      ChartRenderingInfo info = chartViewer.getCanvas().getRenderingInfo();
+      ChartEntity entity = null;
+      if (info != null) {
+        EntityCollection entities = info.getEntityCollection();
+        if (entities != null) {
+          entity = entities.getEntity(x, y);
+        }
+      }
+      return entity;
+    }
+  }
+
+  /**
+   * Example how to create a new handler handles all events and prints them
+   */
+  public void addDebugHandler() {
+    addGestureHandler(ChartGestureHandler.createHandler(Handler.DEBUG, // a preset handler
+        ChartGesture.ALL, // no gesture filters
+        null) // no parameters for this handler
+    );
+  }
+
+  public void clearHandlers() {
+    if (gestureHandlers != null)
+      gestureHandlers.clear();
+  }
+
+  public List<ChartGestureHandler> getGestureHandlers() {
+    return gestureHandlers;
+  }
+
+
+  /**
+   * Handles a mouse moved event. This implementation does nothing, override the method if required.
+   * 
+   * @param canvas the canvas ({@code null} not permitted).
+   * @param e the event ({@code null} not permitted).
+   */
+  @Override
+  public void handleMouseMoved(ChartCanvas chartPanel, MouseEvent eOrig) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.MOVED))
+      return;
+
+    MouseEventWrapper e = new MouseEventWrapper(eOrig);
+    ChartViewWrapper cw = new ChartViewWrapper(chartViewer);
+    ChartEntity entity = findChartEntity(e);
+    ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+    Button button = Button.getButton(e.getButton());
+
+    // handle event
+    handleEvent(
+        new ChartGestureEvent(cw, e, entity, new ChartGesture(gestureEntity, Event.MOVED, button)));
+  }
+
+  /**
+   * Handles a mouse clicked event. This implementation does nothing, override the method if
+   * required.
+   * 
+   * @param canvas the canvas ({@code null} not permitted).
+   * @param e the event ({@code null} not permitted).
+   */
+  @Override
+  public void handleMouseClicked(ChartCanvas chartPanel, MouseEvent eOrig) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty()
+        || !(listensFor(Event.CLICK) || listensFor(Event.DOUBLE_CLICK)))
+      return;
+
+    MouseEventWrapper e = new MouseEventWrapper(eOrig);
+    ChartEntity entity = findChartEntity(e);
+    ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+    Button button = Button.getButton(e.getButton());
+
+    if (!e.isConsumed()) {
+      // double clicked
+      if (e.getClickCount() == 2) {
+        // reset click count to handle double clicks quickly
+        e.consume();
+        // handle event
+        handleEvent(new ChartGestureEvent(cw, e, entity,
+            new ChartGesture(gestureEntity, Event.DOUBLE_CLICK, button)));
+      } else if (e.getClickCount() == 1) {
+        // handle event
+        handleEvent(new ChartGestureEvent(cw, e, entity,
+            new ChartGesture(gestureEntity, Event.CLICK, button)));
+      }
+    }
+  }
+
+  /**
+   * 
+   * @param canvas the canvas ({@code null} not permitted).
+   * @param e the event ({@code null} not permitted).
+   */
+  @Override
+  public void handleMouseReleased(ChartCanvas chartPanel, MouseEvent eOrig) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.RELEASED))
+      return;
+
+    MouseEventWrapper e = new MouseEventWrapper(eOrig);
+    ChartEntity entity = findChartEntity(e);
+    ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+    Button button = Button.getButton(e.getButton());
+
+    // last gesture was dragged? keep the same chartEntity
+    if (lastDragEvent != null) {
+      entity = lastDragEvent.getEntity();
+      gestureEntity = lastDragEvent.getGesture().getEntity();
+    }
+    // handle event
+    handleEvent(new ChartGestureEvent(cw, e, entity,
+        new ChartGesture(gestureEntity, Event.RELEASED, button)));
+
+    // reset drag
+    lastDragEvent = null;
+  }
+
+  /**
+   * Handles a mouse pressed event. This implementation does nothing, override the method if
+   * required.
+   * 
+   * @param canvas the canvas ({@code null} not permitted).
+   * @param e the event ({@code null} not permitted).
+   */
+  @Override
+  public void handleMousePressed(ChartCanvas chartPanel, MouseEvent eOrig) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.PRESSED))
+      return;
+
+    MouseEventWrapper e = new MouseEventWrapper(eOrig);
+    ChartEntity entity = findChartEntity(e);
+    ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+    Button button = Button.getButton(e.getButton());
+    // handle event
+    lastDragEvent = new ChartGestureEvent(cw, e, entity,
+        new ChartGesture(gestureEntity, Event.PRESSED, button));
+    handleEvent(lastDragEvent);
+  }
+
+  /**
+   * Handles a mouse dragged event. This implementation does nothing, override the method if
+   * required.
+   * 
+   * @param canvas the canvas ({@code null} not permitted).
+   * @param e the event ({@code null} not permitted).
+   */
+  @Override
+  public void handleMouseDragged(ChartCanvas chartPanel, MouseEvent eOrig) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.DRAGGED))
+      return;
+
+    MouseEventWrapper e = new MouseEventWrapper(eOrig);
+    // keep the same chartEntity
+    ChartEntity entity = lastDragEvent.getEntity();
+    ChartGesture.Entity gestureEntity = lastDragEvent.getGesture().getEntity();
+    Button button = lastDragEvent.getGesture().getButton();
+
+    // handle event
+    lastDragEvent = new ChartGestureEvent(cw, e, entity,
+        new ChartGesture(gestureEntity, Event.DRAGGED, button));
+    handleEvent(lastDragEvent);
+  }
+
+
+  /**
+   * Handles a scroll event. This implementation does nothing, override the method if required.
+   * 
+   * @param canvas the canvas ({@code null} not permitted).
+   * @param e the event ({@code null} not permitted).
+   */
+  @Override
+  public void handleScroll(ChartCanvas chartPanel, ScrollEvent eOrig) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.MOUSE_WHEEL))
+      return;
+
+    MouseEventWrapper e = new MouseEventWrapper(eOrig);
+    ChartEntity entity = findChartEntity(e);
+    ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+    Button button = Button.getButton(e.getButton());
+
+    // handle event
+    handleEvent(new ChartGestureEvent(cw, e, entity,
+        new ChartGesture(gestureEntity, Event.MOUSE_WHEEL, button)));
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/javafx/EChartViewer.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/javafx/EChartViewer.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.javafx;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.fx.ChartViewer;
+import org.jfree.chart.fx.interaction.MouseHandlerFX;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.CombinedRangeXYPlot;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.Range;
+import org.jfree.data.RangeType;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYZDataset;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuItem;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler;
+import net.sf.mzmine.chartbasics.gestures.interf.GestureHandlerFactory;
+import net.sf.mzmine.chartbasics.graphicsexport.GraphicsExportDialog;
+import net.sf.mzmine.chartbasics.gui.javafx.menu.MenuExportToClipboard;
+import net.sf.mzmine.chartbasics.gui.javafx.menu.MenuExportToExcel;
+import net.sf.mzmine.chartbasics.gui.swing.ChartGestureMouseAdapter;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+import net.sf.mzmine.chartbasics.listener.AxesRangeChangedListener;
+import net.sf.mzmine.chartbasics.listener.AxisRangeChangedListener;
+import net.sf.mzmine.chartbasics.listener.ZoomHistory;
+import net.sf.mzmine.util.io.XSSFExcelWriterReader;
+
+/**
+ * This is an extended version of the ChartViewer (JFreeChartFX). it Adds: ChartGestures (with a set
+ * of standard chart gestures), ZoomHistory, AxesRangeChangeListener, data export, graphics export,
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ *
+ */
+public class EChartViewer extends ChartViewer {
+  private static final long serialVersionUID = 1L;
+  private Logger logger = Logger.getLogger(this.getClass().getName());
+
+  // one history for each plot/subplot
+  protected ZoomHistory zoomHistory;
+  protected List<AxesRangeChangedListener> axesRangeListener;
+  protected boolean isMouseZoomable = true;
+  protected boolean stickyZeroForRangeAxis = false;
+  protected boolean standardGestures = true;
+  // only for XYData (not for categoryPlots)
+  protected boolean addZoomHistory = true;
+  private ChartGestureMouseAdapterFX mouseAdapter;
+
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export<br>
+   * stickyZeroForRangeAxis = false <br>
+   * Graphics and data export menu are added
+   * 
+   * @param chart
+   */
+  public EChartViewer(JFreeChart chart) {
+    this(chart, true, true, true, true, false);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export<br>
+   * stickyZeroForRangeAxis = false
+   * 
+   * @param chart
+   * @param graphicsExportMenu adds graphics export menu
+   * @param standardGestures adds the standard ChartGestureHandlers
+   * @param dataExportMenu adds data export menu
+   */
+  public EChartViewer(JFreeChart chart, boolean graphicsExportMenu, boolean dataExportMenu,
+      boolean standardGestures) {
+    this(chart, graphicsExportMenu, dataExportMenu, standardGestures, false);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export
+   * 
+   * @param chart
+   * @param graphicsExportMenu adds graphics export menu
+   * @param dataExportMenu adds data export menu
+   * @param standardGestures adds the standard ChartGestureHandlers
+   * @param stickyZeroForRangeAxis
+   */
+  public EChartViewer(JFreeChart chart, boolean graphicsExportMenu, boolean dataExportMenu,
+      boolean standardGestures, boolean stickyZeroForRangeAxis) {
+    this(chart, graphicsExportMenu, dataExportMenu, standardGestures, true, stickyZeroForRangeAxis);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export
+   * 
+   * @param chart
+   * @param graphicsExportMenu adds graphics export menu
+   * @param dataExportMenu adds data export menu
+   * @param standardGestures adds the standard ChartGestureHandlers
+   * @param stickyZeroForRangeAxis
+   */
+  public EChartViewer(JFreeChart chart, boolean graphicsExportMenu, boolean dataExportMenu,
+      boolean standardGestures, boolean addZoomHistory, boolean stickyZeroForRangeAxis) {
+    super(null);
+    this.stickyZeroForRangeAxis = stickyZeroForRangeAxis;
+    this.standardGestures = standardGestures;
+    this.addZoomHistory = addZoomHistory;
+    setChart(chart);
+
+    // Add Export to Excel and graphics export menu
+    if (graphicsExportMenu || dataExportMenu)
+      addExportMenu(graphicsExportMenu, dataExportMenu);
+  }
+
+  protected void addMenuItem(Menu parent, String title, EventHandler<ActionEvent> al) {
+    MenuItem pngItem = new MenuItem(title);
+    pngItem.setOnAction(al);
+    parent.getItems().add(pngItem);
+  }
+
+  protected void addMenuItem(ContextMenu parent, String title, EventHandler<ActionEvent> al) {
+    MenuItem pngItem = new MenuItem(title);
+    pngItem.setOnAction(al);
+    parent.getItems().add(pngItem);
+  }
+
+  protected void addMenu(ContextMenu menu, Menu m) {
+    menu.getItems().add(m);
+  }
+
+  @Override
+  public void setChart(JFreeChart chart) {
+    super.setChart(chart);
+    if (chart != null) {
+      initChartPanel();
+    }
+  }
+
+  /**
+   * Init ChartPanel Mouse Listener For MouseDraggedOverAxis event For scrolling X-Axis und zooming
+   * Y-Axis0
+   */
+  private void initChartPanel() {
+    final EChartViewer chartPanel = this;
+
+    // remove old init
+    if (mouseAdapter != null) {
+      this.getCanvas().removeMouseHandler(mouseAdapter);
+    }
+
+    if (chartPanel.getChart().getPlot() instanceof XYPlot) {
+      // set sticky zero
+      if (stickyZeroForRangeAxis) {
+        ValueAxis rangeAxis = chartPanel.getChart().getXYPlot().getRangeAxis();
+        if (rangeAxis instanceof NumberAxis) {
+          NumberAxis axis = (NumberAxis) rangeAxis;
+          axis.setAutoRangeIncludesZero(true);
+          axis.setAutoRange(true);
+          axis.setAutoRangeStickyZero(true);
+          axis.setRangeType(RangeType.POSITIVE);
+        }
+      }
+
+      Plot p = getChart().getPlot();
+      if (addZoomHistory && p instanceof XYPlot
+          && !(p instanceof CombinedDomainXYPlot || p instanceof CombinedRangeXYPlot)) {
+        // zoom history
+        zoomHistory = new ZoomHistory(this, 20);
+
+        // axis range changed listener for zooming and more
+        ValueAxis rangeAxis = this.getChart().getXYPlot().getRangeAxis();
+        ValueAxis domainAxis = this.getChart().getXYPlot().getDomainAxis();
+        if (rangeAxis != null) {
+          rangeAxis.addChangeListener(new AxisRangeChangedListener(new ChartViewWrapper(this)) {
+            @Override
+            public void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+                Range newR) {
+              // notify listeners of changed range
+              if (axesRangeListener != null)
+                for (AxesRangeChangedListener l : axesRangeListener)
+                  l.axesRangeChanged(chart, axis, lastR, newR);
+            }
+          });
+        }
+        if (domainAxis != null) {
+          domainAxis.addChangeListener(new AxisRangeChangedListener(new ChartViewWrapper(this)) {
+            @Override
+            public void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+                Range newR) {
+              // notify listeners of changed range
+              if (axesRangeListener != null)
+                for (AxesRangeChangedListener l : axesRangeListener)
+                  l.axesRangeChanged(chart, axis, lastR, newR);
+            }
+          });
+        }
+      }
+
+      // mouse adapter for scrolling and zooming
+      mouseAdapter = new ChartGestureMouseAdapterFX("gestures", this);
+      addMouseHandler(mouseAdapter);
+
+      // add gestures
+      if (standardGestures) {
+        addStandardGestures();
+      }
+      // mouseAdapter.addDebugHandler();
+    }
+  }
+
+
+  public void addMouseHandler(MouseHandlerFX handler) {
+    this.getCanvas().addAuxiliaryMouseHandler(handler);
+  }
+
+  /**
+   * Adds all standard gestures defined in {@link ChartGestureHandler#getStandardGestures()}
+   */
+  public void addStandardGestures() {
+    // add ChartGestureHandlers
+    ChartGestureMouseAdapterFX m = getGestureAdapter();
+    if (m != null) {
+      m.clearHandlers();
+      for (GestureHandlerFactory f : ChartGestureHandler.getStandardGestures())
+        m.addGestureHandler(f.createHandler());
+
+      logger.log(Level.INFO, "Added standard gestures: " + m.getGestureHandlers().size());
+    }
+  }
+
+  /**
+   * Adds the GraphicsExportDialog menu and the data export menu
+   */
+  protected void addExportMenu(boolean graphics, boolean data) {
+    if (graphics) {
+      // Graphics Export
+      addMenuItem(getContextMenu(), "Export graphics...",
+          e -> GraphicsExportDialog.openDialog(getChart()));
+    }
+    if (data) {
+      // General data export
+      Menu export = new Menu("Export data ...");
+      // Excel XY
+      MenuExportToExcel exportXY =
+          new MenuExportToExcel(new XSSFExcelWriterReader(), "to Excel", this);
+      export.getItems().add(exportXY);
+      // clip board
+      MenuExportToClipboard exportXYClipboard = new MenuExportToClipboard("to Clipboard", this);
+      export.getItems().add(exportXYClipboard);
+      // add to panel
+      addMenu(getContextMenu(), export);
+    }
+  }
+
+  /**
+   * Default tries to extract all series from an XYDataset or XYZDataset<br>
+   * series 1 | Series 2 <br>
+   * x y x y x y z x y z
+   * 
+   * @return Data array[columns][rows]
+   */
+  public Object[][] getDataArrayForExport() {
+    if (getChart().getPlot() instanceof XYPlot && getChart().getXYPlot() != null
+        && getChart().getXYPlot().getDataset() != null) {
+      try {
+        List<Object[]> modelList = new ArrayList<>();
+
+        for (int d = 0; d < getChart().getXYPlot().getDatasetCount(); d++) {
+          XYDataset data = getChart().getXYPlot().getDataset(d);
+          if (data instanceof XYZDataset) {
+            XYZDataset xyz = (XYZDataset) data;
+            int series = data.getSeriesCount();
+            Object[][] model = new Object[series * 3][];
+            for (int s = 0; s < series; s++) {
+              int size = 2 + xyz.getItemCount(s);
+              Object[] x = new Object[size];
+              Object[] y = new Object[size];
+              Object[] z = new Object[size];
+              // create new Array model[row][col]
+              // Write header
+              Comparable title = data.getSeriesKey(series);
+              x[0] = title;
+              y[0] = "";
+              z[0] = "";
+              x[1] = getChart().getXYPlot().getDomainAxis().getLabel();
+              y[1] = getChart().getXYPlot().getRangeAxis().getLabel();
+              z[1] = "z-axis";
+              // write data
+              for (int i = 0; i < xyz.getItemCount(s); i++) {
+                x[i + 2] = xyz.getX(s, i);
+                y[i + 2] = xyz.getY(s, i);
+                z[i + 2] = xyz.getZ(s, i);
+              }
+              model[s * 3] = x;
+              model[s * 3 + 1] = y;
+              model[s * 3 + 2] = z;
+            }
+
+            for (Object[] o : model)
+              modelList.add(o);
+          } else {
+            int series = data.getSeriesCount();
+            Object[][] model = new Object[series * 2][];
+            for (int s = 0; s < series; s++) {
+              int size = 2 + data.getItemCount(s);
+              Object[] x = new Object[size];
+              Object[] y = new Object[size];
+              // create new Array model[row][col]
+              // Write header
+              Comparable title = data.getSeriesKey(s);
+              x[0] = title;
+              y[0] = "";
+              x[1] = getChart().getXYPlot().getDomainAxis().getLabel();
+              y[1] = getChart().getXYPlot().getRangeAxis().getLabel();
+              // write data
+              for (int i = 0; i < data.getItemCount(s); i++) {
+                x[i + 2] = data.getX(s, i);
+                y[i + 2] = data.getY(s, i);
+              }
+              model[s * 2] = x;
+              model[s * 2 + 1] = y;
+            }
+
+            for (Object[] o : model)
+              modelList.add(o);
+          }
+        }
+
+        return modelList.toArray(new Object[modelList.size()][]);
+      } catch (Exception ex) {
+        logger.log(Level.WARNING, "Cannot retrieve data for export", ex);
+        return null;
+      }
+    }
+    return null;
+  }
+
+  public void addAxesRangeChangedListener(AxesRangeChangedListener l) {
+    if (axesRangeListener == null)
+      axesRangeListener = new ArrayList<AxesRangeChangedListener>(1);
+    axesRangeListener.add(l);
+  }
+
+  public void removeAxesRangeChangedListener(AxesRangeChangedListener l) {
+    if (axesRangeListener != null)
+      axesRangeListener.remove(l);
+  }
+
+  public void clearAxesRangeChangedListeners() {
+    if (axesRangeListener != null)
+      axesRangeListener.clear();
+  }
+
+  public void setMouseZoomable(boolean flag) {
+    setDomainZoomable(flag);
+    setRangeZoomable(flag);
+    isMouseZoomable = flag;
+  }
+
+
+  public void setRangeZoomable(boolean flag) {
+    getCanvas().setRangeZoomable(flag);
+  }
+
+  public void setDomainZoomable(boolean flag) {
+    getCanvas().setDomainZoomable(flag);
+  }
+
+  public boolean isMouseZoomable() {
+    return isMouseZoomable;
+  }
+
+  public boolean isDomainZoomable() {
+    return getCanvas().isDomainZoomable();
+  }
+
+  public boolean isRangeZoomable() {
+    return getCanvas().isRangeZoomable();
+  }
+
+  public ZoomHistory getZoomHistory() {
+    return zoomHistory;
+  }
+
+  public void setZoomHistory(ZoomHistory h) {
+    zoomHistory = h;
+  }
+
+  /**
+   * Returns the {@link ChartGestureMouseAdapter} alternatively for other ChartPanel classes use:
+   * 
+   * <pre>
+   * for(MouseListener l : getMouseListeners())
+   *    if(ChartGestureMouseAdapter.class.isInstance(l)){
+   *        ChartGestureMouseAdapter m = (ChartGestureMouseAdapter) l;
+   * </pre>
+   * 
+   * @return
+   */
+  public ChartGestureMouseAdapterFX getGestureAdapter() {
+    return mouseAdapter;
+  }
+
+  public void setGestureAdapter(ChartGestureMouseAdapterFX mouseAdapter) {
+    this.mouseAdapter = mouseAdapter;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/javafx/demo/FXCategoryChartGestureDemo.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/javafx/demo/FXCategoryChartGestureDemo.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.javafx.demo;
+
+
+import java.util.Random;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.category.CategoryDataset;
+import org.jfree.data.category.DefaultCategoryDataset;
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import net.sf.mzmine.chartbasics.gui.javafx.EChartViewer;
+
+public class FXCategoryChartGestureDemo extends Application {
+
+  @Override
+  public void start(Stage stage) throws Exception {
+    JFreeChart chart = ChartFactory.createBarChart("Random", "Category", "value", createDataset());
+    EChartViewer canvas = new EChartViewer(chart);
+    StackPane stackPane = new StackPane();
+    stackPane.getChildren().add(canvas);
+    stage.setScene(new Scene(stackPane));
+    stage.setTitle("Chart gesture demo");
+    stage.setWidth(700);
+    stage.setHeight(390);
+    stage.show();
+  }
+
+  /**
+   * Creates a dataset, consisting of two series of monthly data.
+   *
+   * @return the dataset.
+   */
+  private static CategoryDataset createDataset() {
+    DefaultCategoryDataset data = new DefaultCategoryDataset();
+    Random r = new Random(System.currentTimeMillis());
+    for (int i = 0; i < 3; i++) {
+      for (int t = 0; t < 2; t++) {
+
+        for (int x = 0; x < 100; x++) {
+          double v = r.nextGaussian() * (i + 1);
+          data.addValue(v, "series" + i, "type" + t);
+        }
+      }
+    }
+    return data;
+  }
+
+
+  /**
+   * @param args the command line arguments
+   */
+  public static void main(String[] args) {
+    launch(args);
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/javafx/demo/FXChartGestureDemo.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/javafx/demo/FXChartGestureDemo.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.javafx.demo;
+
+
+import java.util.Random;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import net.sf.mzmine.chartbasics.gui.javafx.EChartViewer;
+
+public class FXChartGestureDemo extends Application {
+
+  @Override
+  public void start(Stage stage) throws Exception {
+    XYDataset dataset = createDataset();
+    JFreeChart chart = ChartFactory.createXYLineChart("Random", "i", "r", createDataset());
+    EChartViewer canvas = new EChartViewer(chart);
+    StackPane stackPane = new StackPane();
+    stackPane.getChildren().add(canvas);
+    stage.setScene(new Scene(stackPane));
+    stage.setTitle("Chart gesture demo");
+    stage.setWidth(700);
+    stage.setHeight(390);
+    stage.show();
+  }
+
+  /**
+   * Creates a dataset, consisting of two series of monthly data.
+   *
+   * @return the dataset.
+   */
+  private static XYDataset createDataset() {
+    XYSeriesCollection data = new XYSeriesCollection();
+
+    Random r = new Random(System.currentTimeMillis());
+
+    for (int i = 0; i < 3; i++) {
+      XYSeries s = new XYSeries("Series" + i);
+      for (int x = 0; x < 100; x++) {
+        double v = r.nextGaussian() * (i + 1);
+        s.add(x, v);
+      }
+      data.addSeries(s);
+    }
+    return data;
+  }
+
+
+  /**
+   * @param args the command line arguments
+   */
+  public static void main(String[] args) {
+    launch(args);
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/javafx/demo/FXCombinedChartGestureDemo.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/javafx/demo/FXCombinedChartGestureDemo.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.javafx.demo;
+
+
+import java.util.Random;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.AxisLocation;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.StandardXYItemRenderer;
+import org.jfree.chart.renderer.xy.XYItemRenderer;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import net.sf.mzmine.chartbasics.gui.javafx.EChartViewer;
+
+public class FXCombinedChartGestureDemo extends Application {
+
+  @Override
+  public void start(Stage stage) throws Exception {
+	  try {
+		    JFreeChart chart = createCombinedChart();
+		    EChartViewer canvas = new EChartViewer(chart);
+		    StackPane stackPane = new StackPane();
+		    stackPane.getChildren().add(canvas);
+		    stage.setScene(new Scene(stackPane));
+		    stage.setTitle("Chart gesture demo");
+		    stage.setWidth(700);
+		    stage.setHeight(390);
+		    stage.show();
+	} catch (Exception e) {
+		e.printStackTrace();
+	}
+  }
+
+  private JFreeChart createCombinedChart() {
+      // create subplot 1...
+      final XYDataset data1 = createDataset();
+      final XYItemRenderer renderer1 = new StandardXYItemRenderer();
+      final NumberAxis rangeAxis1 = new NumberAxis("Range 1");
+      final XYPlot subplot1 = new XYPlot(data1, null, rangeAxis1, renderer1);
+      
+      // create subplot 2...
+      final XYDataset data2 = createDataset();
+      final XYItemRenderer renderer2 = new StandardXYItemRenderer();
+      final NumberAxis rangeAxis2 = new NumberAxis("Range 2");
+      final XYPlot subplot2 = new XYPlot(data2, null, rangeAxis2, renderer2);
+
+      // parent plot...
+      final CombinedDomainXYPlot plot = new CombinedDomainXYPlot(new NumberAxis("Domain"));
+      plot.setGap(10.0);
+      
+      // add the subplots...
+      plot.add(subplot1, 1);
+      plot.add(subplot2, 1);
+      plot.setOrientation(PlotOrientation.VERTICAL);
+
+      // return a new chart containing the overlaid plot...
+      return new JFreeChart("CombinedDomainXYPlot Demo",
+                            JFreeChart.DEFAULT_TITLE_FONT, plot, true);
+}
+
+/**
+   * Creates a dataset, consisting of two series of monthly data.
+   *
+   * @return the dataset.
+   */
+  private static XYDataset createDataset() {
+    XYSeriesCollection data = new XYSeriesCollection();
+
+    Random r = new Random(System.currentTimeMillis());
+
+    for (int i = 0; i < 3; i++) {
+      XYSeries s = new XYSeries("Series" + i);
+      for (int x = 0; x < 100; x++) {
+        double v = r.nextGaussian() * (i + 1);
+        s.add(x, v);
+      }
+      data.addSeries(s);
+    }
+    return data;
+  }
+
+
+  /**
+   * @param args the command line arguments
+   */
+  public static void main(String[] args) {
+    launch(args);
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/javafx/menu/MenuExportToClipboard.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/javafx/menu/MenuExportToClipboard.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.javafx.menu;
+
+import javafx.scene.control.MenuItem;
+import net.sf.mzmine.chartbasics.gui.javafx.EChartViewer;
+import net.sf.mzmine.chartbasics.gui.swing.menu.MenuExport;
+import net.sf.mzmine.util.io.ClipboardWriter;
+
+
+public class MenuExportToClipboard extends MenuItem implements MenuExport {
+  private static final long serialVersionUID = 1L;
+
+  private EChartViewer chart;
+
+  public MenuExportToClipboard(String menuTitle, EChartViewer chart) {
+    super(menuTitle);
+    this.chart = chart;
+    setOnAction(e -> exportDataToClipboard());
+  }
+
+  public void exportDataToClipboard() {
+    Object[][] model = chart.getDataArrayForExport();
+    if (model != null)
+      ClipboardWriter.writeToClipBoard(model, false);
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/javafx/menu/MenuExportToExcel.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/javafx/menu/MenuExportToExcel.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.javafx.menu;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import javafx.scene.control.MenuItem;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+import net.sf.mzmine.chartbasics.gui.javafx.EChartViewer;
+import net.sf.mzmine.chartbasics.gui.swing.menu.MenuExport;
+import net.sf.mzmine.util.files.FileAndPathUtil;
+import net.sf.mzmine.util.io.XSSFExcelWriterReader;
+
+
+public class MenuExportToExcel extends MenuItem implements MenuExport {
+  private static final long serialVersionUID = 1L;
+  private Logger logger = Logger.getLogger(this.getClass().getName());
+
+  private FileChooser fc;
+
+  private XSSFExcelWriterReader excelWriter;
+  private EChartViewer chart;
+
+  public MenuExportToExcel(XSSFExcelWriterReader excelWriter, String menuTitle,
+      EChartViewer chart) {
+    super(menuTitle);
+    this.excelWriter = excelWriter;
+    this.chart = chart;
+    setOnAction(e -> {
+      if (fc == null) {
+        fc = new FileChooser();
+        fc.getExtensionFilters().add(new ExtensionFilter("Microsoft Excel table", "*.xlsx"));
+      }
+      File f = fc.showSaveDialog(null);
+      if (f != null) {
+        exportDataToExcel(f);
+      }
+    });
+  }
+
+  public void exportDataToExcel(File f) {
+    try {
+      logger.info("retrieving data for export to excel");
+      Object[][] data = chart.getDataArrayForExport();
+      if (data != null) {
+        f = FileAndPathUtil.getRealFilePath(f, "xlsx");
+        logger.info("Exporting data to excel file: " + f.getAbsolutePath());
+        XSSFWorkbook wb = excelWriter.exportDataArrayToFile(f, "xydata", data, false);
+        excelWriter.closeWorkbook(wb);
+      }
+    } catch (InvalidFormatException | IOException e1) {
+      logger.log(Level.WARNING, "Cannot export to excel", e1);
+    }
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/swing/ChartGestureMouseAdapter.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/swing/ChartGestureMouseAdapter.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.swing;
+
+import java.awt.Insets;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.entity.EntityCollection;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureDragDiffHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureEvent;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Button;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Entity;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Event;
+import net.sf.mzmine.chartbasics.gestures.ChartGesture.Key;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureDragDiffHandler.Orientation;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler.DragHandler;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler.Handler;
+
+/**
+ * Handles all MouseEvents (like a MouseAdapter) and transforms them into {@link ChartGestureEvent}s
+ * which are then handled by a list of {@link ChartGestureHandler}s.
+ * <p>
+ * Add this adapter to a ChartPanel as a mouse and mousewheel listener.
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ChartGestureMouseAdapter extends MouseAdapter {
+  private int lastEntityX = -1, lastEntityY = -1;
+  private ChartEntity lastEntity = null;
+  private ChartGestureEvent lastDragEvent = null;
+
+  // handle gestures
+  private List<ChartGestureHandler> gestureHandlers;
+  // listen for
+  private HashMap<Event, Boolean> listensFor = new HashMap<Event, Boolean>(Event.values().length);
+
+  /**
+   * True if Event.ALL or e was added as part of a gesture handler
+   * 
+   * @param e
+   * @return
+   */
+  private boolean listensFor(Event e) {
+    return listensFor.get(Event.ALL) || listensFor.get(e);
+  }
+
+  /**
+   * Call all handlers for a specific Gesture Also call all parent handlers (AXIS is parent entity
+   * of RANGE_AXIS entity ALL is parent of all events/entities)
+   * 
+   * @param e
+   */
+  private void handleEvent(final ChartGestureEvent e) {
+    if (gestureHandlers != null)
+      gestureHandlers.stream().filter(handler -> handler.getGesture().filter(e.getGesture()))
+          .forEach(handler -> handler.accept(e));
+  }
+
+  /**
+   * Add drag handlers for each key (key and handler have to be ordered)
+   * 
+   * @param g
+   * @param handler
+   */
+  public void addDragGestureHandler(DragHandler[] handler, Key[] key, Entity entity, Button button,
+      Orientation orient, Object[] param) {
+    ChartGestureHandler h =
+        ChartGestureHandler.createDragDiffHandler(handler, key, entity, button, orient, param);
+    addGestureHandler(h);
+  }
+
+  /**
+   * Add a preset handler for specific gestures and ChartMouseGestureEvents
+   * 
+   * @param g
+   * @param handler
+   */
+  public void addGestureHandler(Handler handler, Entity entity, Event[] event, Button button,
+      Key key, Object[] param) {
+    ChartGestureHandler h = ChartGestureHandler.createHandler(handler,
+        new ChartGesture(entity, event, button, key), param);
+    addGestureHandler(h);
+  }
+
+  /**
+   * Add a handler for specific gestures and ChartMouseGestureEvents
+   * 
+   * @param g
+   * @param handler
+   */
+  public void addGestureHandler(ChartGestureHandler handler) {
+    if (gestureHandlers == null) {
+      gestureHandlers = new ArrayList<ChartGestureHandler>();
+      for (Event e : Event.values())
+        listensFor.put(e, false);
+    }
+
+    gestureHandlers.add(handler);
+    for (Event e : handler.getGesture().getEvent())
+      listensFor.replace(e, true);
+  }
+
+  /**
+   * Add a handler for specific gestures and ChartMouseGestureEvents
+   * 
+   * @param g
+   * @param handler
+   */
+  public void removeGestureHandler(ChartGestureHandler handler) {
+    if (gestureHandlers == null)
+      return;
+
+    if (gestureHandlers.remove(handler)) {
+      // reset listenFor
+      for (Event e : Event.values())
+        listensFor.replace(e, false);
+
+      // set all again
+      for (ChartGestureHandler gh : gestureHandlers)
+        for (Event e : gh.getGesture().getEvent())
+          listensFor.replace(e, true);
+    }
+  }
+
+  /**
+   * Find chartentities like JFreeChartEntity, AxisEntity, PlotEntity, TitleEntity, XY...
+   * 
+   * @param chartPanel
+   * @param x
+   * @param y
+   * @return
+   */
+  private ChartEntity findChartEntity(ChartPanel chartPanel, MouseEvent e) {
+    // coordinates to find chart entities
+    Insets insets = chartPanel.getInsets();
+    int x = (int) ((e.getX() - insets.left) / chartPanel.getScaleX());
+    int y = (int) ((e.getY() - insets.top) / chartPanel.getScaleY());
+
+    if (lastEntity != null && x == lastEntityX && y == lastEntityY)
+      return lastEntity;
+    else {
+      ChartRenderingInfo info = chartPanel.getChartRenderingInfo();
+      ChartEntity entity = null;
+      if (info != null) {
+        EntityCollection entities = info.getEntityCollection();
+        if (entities != null) {
+          entity = entities.getEntity(x, y);
+        }
+      }
+      return entity;
+    }
+  }
+
+  @Override
+  public void mouseClicked(MouseEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty()
+        || !(listensFor(Event.CLICK) || listensFor(Event.DOUBLE_CLICK)))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      ChartEntity entity = findChartEntity(chartPanel, e);
+      ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+      Button button = Button.getButton(e.getButton());
+
+      if (!e.isConsumed()) {
+        // double clicked
+        if (e.getClickCount() == 2) {
+          // reset click count to handle double clicks quickly
+          e.consume();
+          // handle event
+          handleEvent(new ChartGestureEvent(chartPanel, e, entity,
+              new ChartGesture(gestureEntity, Event.DOUBLE_CLICK, button)));
+        } else if (e.getClickCount() == 1) {
+          // handle event
+          handleEvent(new ChartGestureEvent(chartPanel, e, entity,
+              new ChartGesture(gestureEntity, Event.CLICK, button)));
+        }
+      }
+    }
+  }
+
+  @Override
+  public void mouseReleased(MouseEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.RELEASED))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      ChartEntity entity = findChartEntity(chartPanel, e);
+      ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+      Button button = Button.getButton(e.getButton());
+
+      // last gesture was dragged? keep the same chartEntity
+      if (lastDragEvent != null) {
+        entity = lastDragEvent.getEntity();
+        gestureEntity = lastDragEvent.getGesture().getEntity();
+      }
+      // handle event
+      handleEvent(new ChartGestureEvent(chartPanel, e, entity,
+          new ChartGesture(gestureEntity, Event.RELEASED, button)));
+
+      // reset drag
+      lastDragEvent = null;
+    }
+  }
+
+  @Override
+  public void mousePressed(MouseEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.PRESSED))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      ChartEntity entity = findChartEntity(chartPanel, e);
+      ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+      Button button = Button.getButton(e.getButton());
+      // handle event
+      lastDragEvent = new ChartGestureEvent(chartPanel, e, entity,
+          new ChartGesture(gestureEntity, Event.PRESSED, button));
+      handleEvent(lastDragEvent);
+    }
+  }
+
+  @Override
+  public void mouseDragged(MouseEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.DRAGGED))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      // keep the same chartEntity
+      ChartEntity entity = lastDragEvent.getEntity();
+      ChartGesture.Entity gestureEntity = lastDragEvent.getGesture().getEntity();
+      Button button = lastDragEvent.getGesture().getButton();
+
+      // handle event
+      lastDragEvent = new ChartGestureEvent(chartPanel, e, entity,
+          new ChartGesture(gestureEntity, Event.DRAGGED, button));
+      handleEvent(lastDragEvent);
+    }
+  }
+
+  @Override
+  public void mouseMoved(MouseEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.MOVED))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      ChartEntity entity = findChartEntity(chartPanel, e);
+      ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+      Button button = Button.getButton(e.getButton());
+
+      // handle event
+      handleEvent(new ChartGestureEvent(chartPanel, e, entity,
+          new ChartGesture(gestureEntity, Event.MOVED, button)));
+    }
+  }
+
+
+  @Override
+  public void mouseWheelMoved(MouseWheelEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.MOUSE_WHEEL))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      ChartEntity entity = findChartEntity(chartPanel, e);
+      ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+      Button button = Button.getButton(e.getButton());
+
+      // handle event
+      handleEvent(new ChartGestureEvent(chartPanel, e, entity,
+          new ChartGesture(gestureEntity, Event.MOUSE_WHEEL, button)));
+    }
+  }
+
+  @Override
+  public void mouseEntered(MouseEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.ENTERED))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      ChartEntity entity = findChartEntity(chartPanel, e);
+      ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+      Button button = Button.getButton(e.getButton());
+
+      // handle event
+      handleEvent(new ChartGestureEvent(chartPanel, e, entity,
+          new ChartGesture(gestureEntity, Event.ENTERED, button)));
+    }
+  }
+
+  @Override
+  public void mouseExited(MouseEvent e) {
+    if (gestureHandlers == null || gestureHandlers.isEmpty() || !listensFor(Event.EXITED))
+      return;
+
+    if (e.getComponent() instanceof ChartPanel) {
+      ChartPanel chartPanel = (ChartPanel) e.getComponent();
+      ChartEntity entity = findChartEntity(chartPanel, e);
+      ChartGesture.Entity gestureEntity = ChartGesture.getGestureEntity(entity);
+      Button button = Button.getButton(e.getButton());
+
+      // handle event
+      handleEvent(new ChartGestureEvent(chartPanel, e, entity,
+          new ChartGesture(gestureEntity, Event.EXITED, button)));
+    }
+  }
+
+
+  /**
+   * Example how to create a new handler handles all events and prints them
+   */
+  public void addDebugHandler() {
+    addGestureHandler(ChartGestureHandler.createHandler(Handler.DEBUG, // a preset handler
+        ChartGesture.ALL, // no gesture filters
+        null) // no parameters for this handler
+    );
+  }
+
+  public void clearHandlers() {
+    if (gestureHandlers != null)
+      gestureHandlers.clear();
+  }
+
+  public List<ChartGestureHandler> getGestureHandlers() {
+    return gestureHandlers;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/swing/EChartPanel.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/swing/EChartPanel.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.swing;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.JFileChooser;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.ChartUtils;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.CombinedRangeXYPlot;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.Range;
+import org.jfree.data.RangeType;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYZDataset;
+import net.sf.mzmine.chartbasics.gestures.ChartGestureHandler;
+import net.sf.mzmine.chartbasics.gestures.interf.GestureHandlerFactory;
+import net.sf.mzmine.chartbasics.graphicsexport.ChartExportUtil;
+import net.sf.mzmine.chartbasics.gui.swing.menu.JMenuExportToClipboard;
+import net.sf.mzmine.chartbasics.gui.swing.menu.JMenuExportToExcel;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+import net.sf.mzmine.chartbasics.listener.AxesRangeChangedListener;
+import net.sf.mzmine.chartbasics.listener.AxisRangeChangedListener;
+import net.sf.mzmine.chartbasics.listener.ZoomHistory;
+import net.sf.mzmine.util.io.XSSFExcelWriterReader;
+
+/**
+ * Enhanced ChartPanel with extra chart gestures (drag mouse over entities (e.g., axis, titles)
+ * ZoomHistory, GraphicsExportDialog, axesRangeListener included
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class EChartPanel extends ChartPanel {
+  private static final long serialVersionUID = 1L;
+  private Logger logger = Logger.getLogger(this.getClass().getName());
+
+  protected ZoomHistory zoomHistory;
+  protected List<AxesRangeChangedListener> axesRangeListener;
+  protected boolean isMouseZoomable = true;
+  protected boolean stickyZeroForRangeAxis = false;
+  protected boolean standardGestures = true;
+  // only for XYData (not for categoryPlots)
+  protected boolean addZoomHistory = true;
+  protected ChartGestureMouseAdapter mouseAdapter;
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export<br>
+   * stickyZeroForRangeAxis = false <br>
+   * Graphics and data export menu are added
+   * 
+   * @param chart
+   */
+  public EChartPanel(JFreeChart chart) {
+    this(chart, true, true, true, true, false);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export<br>
+   * stickyZeroForRangeAxis = false <br>
+   * Graphics and data export menu are added
+   * 
+   * @param chart
+   */
+  public EChartPanel(JFreeChart chart, boolean useBuffer) {
+    this(chart, useBuffer, true, true, true, false);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export<br>
+   * stickyZeroForRangeAxis = false
+   * 
+   * @param chart
+   * @param graphicsExportMenu adds graphics export menu
+   * @param standardGestures adds the standard ChartGestureHandlers
+   * @param dataExportMenu adds data export menu
+   */
+  public EChartPanel(JFreeChart chart, boolean graphicsExportMenu, boolean dataExportMenu,
+      boolean standardGestures) {
+    this(chart, graphicsExportMenu, dataExportMenu, standardGestures, false);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export<br>
+   * stickyZeroForRangeAxis = false
+   * 
+   * @param chart
+   * @param graphicsExportMenu adds graphics export menu
+   * @param standardGestures adds the standard ChartGestureHandlers
+   * @param dataExportMenu adds data export menu
+   */
+  public EChartPanel(JFreeChart chart, boolean useBuffer, boolean graphicsExportMenu,
+      boolean dataExportMenu, boolean standardGestures) {
+    this(chart, useBuffer, graphicsExportMenu, dataExportMenu, standardGestures, false);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export
+   * 
+   * @param chart
+   * @param graphicsExportMenu adds graphics export menu
+   * @param dataExportMenu adds data export menu
+   * @param standardGestures adds the standard ChartGestureHandlers
+   * @param stickyZeroForRangeAxis
+   */
+  public EChartPanel(JFreeChart chart, boolean useBuffer, boolean graphicsExportMenu,
+      boolean dataExportMenu, boolean standardGestures, boolean stickyZeroForRangeAxis) {
+    this(chart, useBuffer, graphicsExportMenu, dataExportMenu, standardGestures, true,
+        stickyZeroForRangeAxis);
+  }
+
+  /**
+   * Enhanced ChartPanel with extra scrolling methods, zoom history, graphics and data export
+   * 
+   * @param chart
+   * @param graphicsExportMenu adds graphics export menu
+   * @param dataExportMenu adds data export menu
+   * @param standardGestures adds the standard ChartGestureHandlers
+   * @param stickyZeroForRangeAxis
+   */
+  public EChartPanel(JFreeChart chart, boolean useBuffer, boolean graphicsExportMenu,
+      boolean dataExportMenu, boolean standardGestures, boolean addZoomHistory,
+      boolean stickyZeroForRangeAxis) {
+    super(null, useBuffer);
+    this.stickyZeroForRangeAxis = stickyZeroForRangeAxis;
+    this.standardGestures = standardGestures;
+    this.addZoomHistory = addZoomHistory;
+    setChart(chart);
+    // setDoubleBuffered(useBuffer);
+    // setRefreshBuffer(useBuffer);
+    // Add Export to Excel and graphics export menu
+    if (graphicsExportMenu || dataExportMenu)
+      addExportMenu(graphicsExportMenu, dataExportMenu);
+  }
+
+  /**
+   * Adds all standard gestures defined in {@link ChartGestureHandler#getStandardGestures()}
+   */
+  public void addStandardGestures() {
+    // add ChartGestureHandlers
+    ChartGestureMouseAdapter m = getGestureAdapter();
+    if (m != null) {
+      m.clearHandlers();
+      for (GestureHandlerFactory f : ChartGestureHandler.getStandardGestures())
+        m.addGestureHandler(f.createHandler());
+
+      logger.log(Level.INFO, "Added standard gestures: " + m.getGestureHandlers().size());
+    }
+  }
+
+  @Override
+  public void setChart(JFreeChart chart) {
+    super.setChart(chart);
+    if (chart != null) {
+      initChartPanel(stickyZeroForRangeAxis);
+    }
+  }
+
+  /**
+   * Init ChartPanel Mouse Listener For MouseDraggedOverAxis event For scrolling X-Axis und zooming
+   * Y-Axis0
+   */
+  private void initChartPanel(boolean stickyZeroForRangeAxis) {
+    final EChartPanel chartPanel = this;
+
+    // remove old init
+    if (mouseAdapter != null) {
+      this.removeMouseListener(mouseAdapter);
+      this.removeMouseMotionListener(mouseAdapter);
+      this.removeMouseWheelListener(mouseAdapter);
+    }
+
+    if (chartPanel.getChart().getPlot() instanceof XYPlot) {
+      // set sticky zero
+      if (stickyZeroForRangeAxis) {
+        ValueAxis rangeAxis = chartPanel.getChart().getXYPlot().getRangeAxis();
+        if (rangeAxis instanceof NumberAxis) {
+          NumberAxis axis = (NumberAxis) rangeAxis;
+          axis.setAutoRangeIncludesZero(true);
+          axis.setAutoRange(true);
+          axis.setAutoRangeStickyZero(true);
+          axis.setRangeType(RangeType.POSITIVE);
+        }
+      }
+
+      Plot p = getChart().getPlot();
+      if (addZoomHistory && (p instanceof XYPlot)
+          && !(p instanceof CombinedDomainXYPlot || p instanceof CombinedRangeXYPlot)) {
+        // zoom history
+        zoomHistory = new ZoomHistory(this, 20);
+
+        // axis range changed listener for zooming and more
+        ValueAxis rangeAxis = this.getChart().getXYPlot().getRangeAxis();
+        ValueAxis domainAxis = this.getChart().getXYPlot().getDomainAxis();
+        if (rangeAxis != null) {
+          rangeAxis.addChangeListener(new AxisRangeChangedListener(new ChartViewWrapper(this)) {
+            @Override
+            public void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+                Range newR) {
+              // notify listeners of changed range
+              if (axesRangeListener != null)
+                for (AxesRangeChangedListener l : axesRangeListener)
+                  l.axesRangeChanged(chart, axis, lastR, newR);
+            }
+          });
+        }
+        if (domainAxis != null) {
+          domainAxis.addChangeListener(new AxisRangeChangedListener(new ChartViewWrapper(this)) {
+            @Override
+            public void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+                Range newR) {
+              // notify listeners of changed range
+              if (axesRangeListener != null)
+                for (AxesRangeChangedListener l : axesRangeListener)
+                  l.axesRangeChanged(chart, axis, lastR, newR);
+            }
+          });
+        }
+      }
+
+      // mouse adapter for scrolling and zooming
+      mouseAdapter = new ChartGestureMouseAdapter();
+      // mouseAdapter.addDebugHandler();
+      this.addMouseListener(mouseAdapter);
+      this.addMouseMotionListener(mouseAdapter);
+      this.addMouseWheelListener(mouseAdapter);
+
+      // add gestures
+      if (standardGestures) {
+        addStandardGestures();
+      }
+    }
+  }
+
+  @Override
+  public void setMouseZoomable(boolean flag) {
+    super.setMouseZoomable(flag);
+    isMouseZoomable = flag;
+  }
+
+  /**
+   * Default tries to extract all series from an XYDataset or XYZDataset<br>
+   * series 1 | Series 2 <br>
+   * x y x y x y z x y z
+   * 
+   * @return Data array[columns][rows]
+   */
+  public Object[][] getDataArrayForExport() {
+    if (getChart().getPlot() instanceof XYPlot && getChart().getXYPlot() != null
+        && getChart().getXYPlot().getDataset() != null) {
+      try {
+        List<Object[]> modelList = new ArrayList<>();
+
+        for (int d = 0; d < getChart().getXYPlot().getDatasetCount(); d++) {
+          XYDataset data = getChart().getXYPlot().getDataset(d);
+          if (data instanceof XYZDataset) {
+            XYZDataset xyz = (XYZDataset) data;
+            int series = data.getSeriesCount();
+            Object[][] model = new Object[series * 3][];
+            for (int s = 0; s < series; s++) {
+              int size = 2 + xyz.getItemCount(s);
+              Object[] x = new Object[size];
+              Object[] y = new Object[size];
+              Object[] z = new Object[size];
+              // create new Array model[row][col]
+              // Write header
+              Comparable title = data.getSeriesKey(series);
+              x[0] = title;
+              y[0] = "";
+              z[0] = "";
+              x[1] = getChart().getXYPlot().getDomainAxis().getLabel();
+              y[1] = getChart().getXYPlot().getRangeAxis().getLabel();
+              z[1] = "z-axis";
+              // write data
+              for (int i = 0; i < xyz.getItemCount(s); i++) {
+                x[i + 2] = xyz.getX(s, i);
+                y[i + 2] = xyz.getY(s, i);
+                z[i + 2] = xyz.getZ(s, i);
+              }
+              model[s * 3] = x;
+              model[s * 3 + 1] = y;
+              model[s * 3 + 2] = z;
+            }
+
+            for (Object[] o : model)
+              modelList.add(o);
+          } else {
+            int series = data.getSeriesCount();
+            Object[][] model = new Object[series * 2][];
+            for (int s = 0; s < series; s++) {
+              int size = 2 + data.getItemCount(s);
+              Object[] x = new Object[size];
+              Object[] y = new Object[size];
+              // create new Array model[row][col]
+              // Write header
+              Comparable title = data.getSeriesKey(s);
+              x[0] = title;
+              y[0] = "";
+              x[1] = getChart().getXYPlot().getDomainAxis().getLabel();
+              y[1] = getChart().getXYPlot().getRangeAxis().getLabel();
+              // write data
+              for (int i = 0; i < data.getItemCount(s); i++) {
+                x[i + 2] = data.getX(s, i);
+                y[i + 2] = data.getY(s, i);
+              }
+              model[s * 2] = x;
+              model[s * 2 + 1] = y;
+            }
+
+            for (Object[] o : model)
+              modelList.add(o);
+          }
+        }
+
+        return modelList.toArray(new Object[modelList.size()][]);
+      } catch (Exception ex) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /*
+   * ############################################################### Export Graphics
+   */
+  /**
+   * Adds the GraphicsExportDialog menu and the data export menu
+   */
+  protected void addExportMenu(boolean graphics, boolean data) {
+    this.getPopupMenu().addSeparator();
+    if (graphics) {
+      // Graphics Export
+      ChartExportUtil.addExportDialogToMenu(this);
+    }
+    if (data) {
+      // General data export
+      JMenu export = new JMenu("Export data ...");
+      // Excel XY
+      JMenuExportToExcel exportXY =
+          new JMenuExportToExcel(new XSSFExcelWriterReader(), "to Excel", this);
+      export.add(exportXY);
+      // clip board
+      JMenuExportToClipboard exportXYClipboard = new JMenuExportToClipboard("to Clipboard", this);
+      export.add(exportXYClipboard);
+      // add to panel
+      addPopupMenu(export);
+    }
+  }
+
+  public void addPopupMenuItem(JMenuItem item) {
+    this.getPopupMenu().add(item);
+  }
+
+  public void addPopupMenu(JMenu menu) {
+    this.getPopupMenu().add(menu);
+  }
+
+  /**
+   * Opens a file chooser and gives the user an opportunity to save the chart in PNG format.
+   *
+   * @throws IOException if there is an I/O error.
+   */
+  @Override
+  public void doSaveAs() throws IOException {
+    JFileChooser fileChooser = new JFileChooser();
+    fileChooser.setCurrentDirectory(this.getDefaultDirectoryForSaveAs());
+    FileNameExtensionFilter filter =
+        new FileNameExtensionFilter(localizationResources.getString("PNG_Image_Files"), "png");
+    fileChooser.addChoosableFileFilter(filter);
+    fileChooser.setFileFilter(filter);
+
+    int option = fileChooser.showSaveDialog(this);
+    if (option == JFileChooser.APPROVE_OPTION) {
+      String filename = fileChooser.getSelectedFile().getPath();
+      if (isEnforceFileExtensions()) {
+        if (!filename.endsWith(".png")) {
+          filename = filename + ".png";
+        }
+      }
+      ChartUtils.saveChartAsPNG(new File(filename), getChart(), getWidth(), getHeight(),
+          getChartRenderingInfo());
+    }
+  }
+
+  public void addAxesRangeChangedListener(AxesRangeChangedListener l) {
+    if (axesRangeListener == null)
+      axesRangeListener = new ArrayList<AxesRangeChangedListener>(1);
+    axesRangeListener.add(l);
+  }
+
+  public void removeAxesRangeChangedListener(AxesRangeChangedListener l) {
+    if (axesRangeListener != null)
+      axesRangeListener.remove(l);
+  }
+
+  public void clearAxesRangeChangedListeners() {
+    if (axesRangeListener != null)
+      axesRangeListener.clear();
+  }
+
+  public boolean isMouseZoomable() {
+    return isMouseZoomable;
+  }
+
+  public ZoomHistory getZoomHistory() {
+    return zoomHistory;
+  }
+
+  /**
+   * Returns the {@link ChartGestureMouseAdapter} alternatively for other ChartPanel classes use:
+   * 
+   * <pre>
+   * for(MouseListener l : getMouseListeners())
+   * 	if(ChartGestureMouseAdapter.class.isInstance(l)){
+   * 		ChartGestureMouseAdapter m = (ChartGestureMouseAdapter) l;
+   * </pre>
+   * 
+   * @return
+   */
+  public ChartGestureMouseAdapter getGestureAdapter() {
+    return mouseAdapter;
+  }
+
+  public void setGestureAdapter(ChartGestureMouseAdapter mouseAdapter) {
+    this.mouseAdapter = mouseAdapter;
+  }
+
+  public void setZoomHistory(ZoomHistory h) {
+    zoomHistory = h;
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/swing/demo/SwingChartGestureDemo.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/swing/demo/SwingChartGestureDemo.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.swing.demo;
+
+
+import java.awt.BorderLayout;
+import java.util.Random;
+import javax.swing.JFrame;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.JFreeChart;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import javafx.scene.layout.StackPane;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+
+public class SwingChartGestureDemo extends JFrame {
+
+  /**
+   * @param args the command line arguments
+   */
+  public static void main(String[] args) {
+    new SwingChartGestureDemo().setVisible(true);
+  }
+
+  public SwingChartGestureDemo() {
+    setSize(800, 600);
+    setTitle("Chart gesture test");
+    XYDataset dataset = createDataset();
+    JFreeChart chart = ChartFactory.createXYLineChart("Random", "i", "r", createDataset());
+    EChartPanel canvas = new EChartPanel(chart);
+    StackPane stackPane = new StackPane();
+    getContentPane().add(canvas, BorderLayout.CENTER);
+  }
+
+  /**
+   * Creates a dataset, consisting of two series of monthly data.
+   *
+   * @return the dataset.
+   */
+  private static XYDataset createDataset() {
+    XYSeriesCollection data = new XYSeriesCollection();
+
+    Random r = new Random(System.currentTimeMillis());
+
+    for (int i = 0; i < 3; i++) {
+      XYSeries s = new XYSeries("Series" + i);
+      for (int x = 0; x < 100; x++) {
+        double v = r.nextGaussian() * (i + 1);
+        s.add(x, v);
+      }
+      data.addSeries(s);
+    }
+    return data;
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/swing/demo/SwingCombinedChartGestureDemo.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/swing/demo/SwingCombinedChartGestureDemo.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.swing.demo;
+
+
+import java.awt.BorderLayout;
+import java.util.Random;
+import javax.swing.JFrame;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.StandardXYItemRenderer;
+import org.jfree.chart.renderer.xy.XYItemRenderer;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+import javafx.scene.layout.StackPane;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+
+public class SwingCombinedChartGestureDemo extends JFrame {
+
+  public SwingCombinedChartGestureDemo() {
+    setSize(800, 600);
+    setTitle("Chart gesture test");
+    JFreeChart chart = createCombinedChart();
+    EChartPanel canvas = new EChartPanel(chart);
+    StackPane stackPane = new StackPane();
+    getContentPane().add(canvas, BorderLayout.CENTER);
+  }
+
+  private JFreeChart createCombinedChart() {
+    // create subplot 1...
+    final XYDataset data1 = createDataset();
+    final XYItemRenderer renderer1 = new StandardXYItemRenderer();
+    final NumberAxis rangeAxis1 = new NumberAxis("Range 1");
+    final XYPlot subplot1 = new XYPlot(data1, null, rangeAxis1, renderer1);
+
+    // create subplot 2...
+    final XYDataset data2 = createDataset();
+    final XYItemRenderer renderer2 = new StandardXYItemRenderer();
+    final NumberAxis rangeAxis2 = new NumberAxis("Range 2");
+    final XYPlot subplot2 = new XYPlot(data2, null, rangeAxis2, renderer2);
+
+    // parent plot...
+    final CombinedDomainXYPlot plot = new CombinedDomainXYPlot(new NumberAxis("Domain"));
+    plot.setGap(10.0);
+
+    // add the subplots...
+    plot.add(subplot1, 1);
+    plot.add(subplot2, 1);
+    plot.setOrientation(PlotOrientation.VERTICAL);
+
+    // return a new chart containing the overlaid plot...
+    return new JFreeChart("CombinedDomainXYPlot Demo", JFreeChart.DEFAULT_TITLE_FONT, plot, true);
+  }
+
+  /**
+   * Creates a dataset, consisting of two series of monthly data.
+   *
+   * @return the dataset.
+   */
+  private static XYDataset createDataset() {
+    XYSeriesCollection data = new XYSeriesCollection();
+
+    Random r = new Random(System.currentTimeMillis());
+
+    for (int i = 0; i < 3; i++) {
+      XYSeries s = new XYSeries("Series" + i);
+      for (int x = 0; x < 100; x++) {
+        double v = r.nextGaussian() * (i + 1);
+        s.add(x, v);
+      }
+      data.addSeries(s);
+    }
+    return data;
+  }
+
+
+  /**
+   * @param args the command line arguments
+   */
+  public static void main(String[] args) {
+    new SwingCombinedChartGestureDemo().setVisible(true);
+  }
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/swing/menu/JMenuExportToClipboard.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/swing/menu/JMenuExportToClipboard.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.swing.menu;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JMenuItem;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+import net.sf.mzmine.util.io.ClipboardWriter;
+
+
+public class JMenuExportToClipboard extends JMenuItem implements MenuExport {
+  private static final long serialVersionUID = 1L;
+
+  private EChartPanel chart;
+
+  public JMenuExportToClipboard(String menuTitle, EChartPanel chart) {
+    super(menuTitle);
+    this.chart = chart;
+    this.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent arg0) {
+        exportDataToClipboard();
+      }
+    });
+  }
+
+  public void exportDataToClipboard() {
+    Object[][] model = chart.getDataArrayForExport();
+    if (model != null)
+      ClipboardWriter.writeToClipBoard(model, false);
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/swing/menu/JMenuExportToExcel.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/swing/menu/JMenuExportToExcel.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.swing.menu;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.IOException;
+import javax.swing.JFileChooser;
+import javax.swing.JMenuItem;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+import net.sf.mzmine.util.files.FileAndPathUtil;
+import net.sf.mzmine.util.io.XSSFExcelWriterReader;
+
+
+public class JMenuExportToExcel extends JMenuItem implements MenuExport {
+  private static final long serialVersionUID = 1L;
+
+  private XSSFExcelWriterReader excelWriter;
+  private EChartPanel chart;
+
+  public JMenuExportToExcel(XSSFExcelWriterReader excelWriter, String menuTitle, EChartPanel chart) {
+    super(menuTitle);
+    this.excelWriter = excelWriter;
+    this.chart = chart;
+    addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        JFileChooser c = XSSFExcelWriterReader.getChooser();
+        if (c.showSaveDialog(chart) == JFileChooser.APPROVE_OPTION) {
+          exportDataToExcel(c.getSelectedFile());
+        }
+      }
+    });
+  }
+
+  public void exportDataToExcel(File f) {
+    try {
+      Object[][] data = chart.getDataArrayForExport();
+      if (data != null) {
+        f = FileAndPathUtil.getRealFilePath(f, "xlsx");
+        XSSFWorkbook wb = excelWriter.exportDataArrayToFile(f, "xydata", data, false);
+        excelWriter.closeWorkbook(wb);
+      }
+    } catch (InvalidFormatException | IOException e1) {
+      e1.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/swing/menu/MenuExport.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/swing/menu/MenuExport.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.swing.menu;
+
+public interface MenuExport {
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/wrapper/ChartViewWrapper.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/wrapper/ChartViewWrapper.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.wrapper;
+
+import java.awt.geom.Point2D;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.fx.ChartViewer;
+import org.jfree.chart.plot.XYPlot;
+import net.sf.mzmine.chartbasics.ChartLogics;
+import net.sf.mzmine.chartbasics.ChartLogicsFX;
+import net.sf.mzmine.chartbasics.gui.javafx.EChartViewer;
+import net.sf.mzmine.chartbasics.gui.swing.EChartPanel;
+import net.sf.mzmine.chartbasics.listener.ZoomHistory;
+
+public class ChartViewWrapper {
+
+  // only one is initialised
+  private ChartPanel cp;
+  private ChartViewer cc;
+
+  public ChartViewWrapper(ChartPanel cp) {
+    super();
+    this.cp = cp;
+  }
+
+  public ChartViewWrapper(ChartViewer cc) {
+    super();
+    this.cc = cc;
+  }
+
+  public ChartViewer getChartFX() {
+    return cc;
+  }
+
+  public ChartPanel getChartSwing() {
+    return cp;
+  }
+
+  public JFreeChart getChart() {
+    return cp != null ? cp.getChart() : cc.getChart();
+  }
+
+  public boolean isFX() {
+    return cc != null;
+  }
+
+  public boolean isSwing() {
+    return !isFX();
+  }
+
+
+  public ChartRenderingInfo getRenderingInfo() {
+    return cp != null ? cp.getChartRenderingInfo() : cc.getRenderingInfo();
+  }
+
+
+  // logics
+  public Point2D mouseXYToPlotXY(double x, double y) {
+    try {
+      return cp != null ? ChartLogics.mouseXYToPlotXY(cp, x, y)
+          : ChartLogicsFX.mouseXYToPlotXY(cc, x, y);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return new Point2D.Double(0, 0);
+    }
+  }
+
+  public boolean isMouseZoomable() {
+    return cp != null ? ChartLogics.isMouseZoomable(cp) : ChartLogicsFX.isMouseZoomable(cc);
+  }
+
+  public void setMouseZoomable(boolean zoomable) {
+    if (cp != null)
+      cp.setMouseZoomable(zoomable);
+    else {
+      if (cc instanceof EChartViewer)
+        ((EChartViewer) cc).setMouseZoomable(zoomable);
+      else {
+        cc.getCanvas().setDomainZoomable(zoomable);
+        cc.getCanvas().setRangeZoomable(zoomable);
+      }
+    }
+  }
+
+
+
+  /**
+   * Auto range the range axis
+   * 
+   */
+  public void autoAxes() {
+    if (cp != null)
+      ChartLogics.autoAxes(cp);
+    else
+      ChartLogicsFX.autoAxes(cc);
+  }
+
+  /**
+   * Auto range the range axis
+   * 
+   */
+  public void autoRangeAxis() {
+    if (cp != null)
+      ChartLogics.autoRangeAxis(cp);
+    else
+      ChartLogicsFX.autoRangeAxis(cc);
+  }
+
+  /**
+   * Auto range the range axis
+   * 
+   */
+  public void autoDomainAxis() {
+    if (cp != null)
+      ChartLogics.autoDomainAxis(cp);
+    else
+      ChartLogicsFX.autoDomainAxis(cc);
+  }
+
+  /**
+   * The ZoomHistory of this ChartPanel/ChartCanvas
+   * 
+   * @return
+   */
+  public ZoomHistory getZoomHistory() {
+    if (cp != null) {
+      if (cp instanceof EChartPanel)
+        return ((EChartPanel) cp).getZoomHistory();
+      else {
+        Object o = cp.getClientProperty(ZoomHistory.PROPERTY_NAME);
+        if (o != null && o instanceof ZoomHistory)
+          return (ZoomHistory) o;
+        else
+          return null;
+      }
+    } else {
+      // fx TODO
+      if (cc instanceof EChartViewer)
+        return ((EChartViewer) cc).getZoomHistory();
+      else
+        return null;
+    }
+  }
+
+  public void setZoomHistory(ZoomHistory h) {
+    if (cp != null) {
+      if (cp instanceof EChartPanel)
+        ((EChartPanel) cp).setZoomHistory(h);
+      else {
+        cp.putClientProperty(h, ZoomHistory.PROPERTY_NAME);
+      }
+    } else {
+      // TODO
+
+      if (cc instanceof EChartViewer)
+        ((EChartViewer) cc).setZoomHistory(h);
+    }
+  }
+
+
+  /**
+   * Subplot or main plot at point
+   * 
+   * @param chart
+   * @param info
+   * @param mouseX
+   * @param mouseY
+   * @return
+   */
+  public XYPlot findXYSubplot(double mouseX, double mouseY) {
+    return cp != null ? ChartLogics.findXYSubplot(getChart(), getRenderingInfo(), mouseX, mouseY)
+        : ChartLogicsFX.findXYSubplot(getChart(), getRenderingInfo(), mouseX, mouseY);
+  }
+
+  /**
+   * Find chartentities like JFreeChartEntity, AxisEntity, PlotEntity, TitleEntity, XY...
+   * 
+   * @param chart
+   * @param mx mouse coordinates
+   * @param my mouse coordinates
+   * @return
+   */
+  public ChartEntity findChartEntity(double mx, double my) {
+    return cp != null ? ChartLogics.findChartEntity(cp, mx, my)
+        : ChartLogicsFX.findChartEntity(cc.getCanvas(), mx, my);
+  }
+}

--- a/src/main/java/io/github/mzmine/chartbasics/gui/wrapper/MouseEventWrapper.java
+++ b/src/main/java/io/github/mzmine/chartbasics/gui/wrapper/MouseEventWrapper.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2006-2015 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.gui.wrapper;
+
+import java.awt.Component;
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
+import java.awt.geom.Point2D;
+
+import javafx.scene.input.ScrollEvent;
+
+public class MouseEventWrapper {
+
+  public enum Type {
+    SWING, FX_MOUSE, FX_SCROLL;
+  }
+
+  private Type type;
+  private MouseEvent swing;
+  private javafx.scene.input.MouseEvent fx;
+  private ScrollEvent scrollfx;
+
+  public MouseEventWrapper(javafx.scene.input.MouseEvent fx) {
+    super();
+    this.fx = fx;
+    type = Type.FX_MOUSE;
+  }
+
+  public MouseEventWrapper(MouseEvent swing) {
+    super();
+    this.swing = swing;
+    type = Type.SWING;
+  }
+
+  public MouseEventWrapper(ScrollEvent scrollfx) {
+    super();
+    this.scrollfx = scrollfx;
+    type = Type.FX_SCROLL;
+  }
+
+  public boolean isFXEvent() {
+    return !isSwingEvent();
+  }
+
+  public boolean isFXMouseEvent() {
+    return type.equals(Type.FX_MOUSE);
+  }
+
+  public boolean isFXScrollEvent() {
+    return type.equals(Type.FX_SCROLL);
+  }
+
+  public boolean isSwingEvent() {
+    return type.equals(Type.SWING);
+  }
+
+  public Object getEvent() {
+    switch (type) {
+      case SWING:
+        return swing;
+      case FX_MOUSE:
+        return fx;
+      case FX_SCROLL:
+        return scrollfx;
+    }
+    return null;
+  }
+
+  public boolean isAltDown() {
+    switch (type) {
+      case SWING:
+        return swing.isAltDown();
+      case FX_MOUSE:
+        return fx.isAltDown();
+      case FX_SCROLL:
+        return scrollfx.isAltDown();
+    }
+    return false;
+  }
+
+  public boolean isShiftDown() {
+    switch (type) {
+      case SWING:
+        return swing.isShiftDown();
+      case FX_MOUSE:
+        return fx.isShiftDown();
+      case FX_SCROLL:
+        return scrollfx.isShiftDown();
+    }
+    return false;
+  }
+
+  public boolean isControlDown() {
+    switch (type) {
+      case SWING:
+        return swing.isControlDown();
+      case FX_MOUSE:
+        return fx.isControlDown();
+      case FX_SCROLL:
+        return scrollfx.isControlDown();
+    }
+    return false;
+  }
+
+  public boolean isMetaDown() {
+    switch (type) {
+      case SWING:
+        return swing.isMetaDown();
+      case FX_MOUSE:
+        return fx.isMetaDown();
+      case FX_SCROLL:
+        return scrollfx.isMetaDown();
+    }
+    return false;
+  }
+
+  public boolean isConsumed() {
+    switch (type) {
+      case SWING:
+        return swing.isConsumed();
+      case FX_MOUSE:
+        return fx.isConsumed();
+      case FX_SCROLL:
+        return scrollfx.isConsumed();
+    }
+    return false;
+  }
+
+  public double getX() {
+    switch (type) {
+      case SWING:
+        return swing.getX();
+      case FX_MOUSE:
+        return fx.getX();
+      case FX_SCROLL:
+        return scrollfx.getX();
+    }
+    return 0;
+  }
+
+  public double getY() {
+    switch (type) {
+      case SWING:
+        return swing.getY();
+      case FX_MOUSE:
+        return fx.getY();
+      case FX_SCROLL:
+        return scrollfx.getY();
+    }
+    return 0;
+  }
+
+  public double getXOnScreen() {
+    switch (type) {
+      case SWING:
+        return swing.getXOnScreen();
+      case FX_MOUSE:
+        return fx.getScreenX();
+      case FX_SCROLL:
+        return scrollfx.getScreenX();
+    }
+    return 0;
+  }
+
+  public double getYOnScreen() {
+    switch (type) {
+      case SWING:
+        return swing.getYOnScreen();
+      case FX_MOUSE:
+        return fx.getScreenY();
+      case FX_SCROLL:
+        return scrollfx.getScreenY();
+    }
+    return 0;
+  }
+
+  public int getClickCount() {
+    switch (type) {
+      case SWING:
+        return swing.getClickCount();
+      case FX_MOUSE:
+        return fx.getClickCount();
+      case FX_SCROLL:
+        return scrollfx.getTouchCount();
+    }
+    return 0;
+  }
+
+  /**
+   * Returns which, if any, of the mouse buttons has changed state. The returned value is ranged
+   * from 0 to the {@link java.awt.MouseInfo#getNumberOfButtons() MouseInfo.getNumberOfButtons()}
+   * value. The returned value includes at least the following constants:
+   * <ul>
+   * <li>{@code NOBUTTON}
+   * <li>{@code BUTTON1}
+   * <li>{@code BUTTON2}
+   * <li>{@code BUTTON3}
+   * </ul>
+   * It is allowed to use those constants to compare with the returned button number in the
+   * application. For example,
+   * 
+   * <pre>
+   * if (anEvent.getButton() == MouseEvent.BUTTON1) {
+   * </pre>
+   * 
+   * In particular, for a mouse with one, two, or three buttons this method may return the following
+   * values:
+   * <ul>
+   * <li>0 ({@code NOBUTTON})
+   * <li>1 ({@code BUTTON1})
+   * <li>2 ({@code BUTTON2})
+   * <li>3 ({@code BUTTON3})
+   * </ul>
+   * Button numbers greater then {@code BUTTON3} have no constant identifier. So if a mouse with
+   * five buttons is installed, this method may return the following values:
+   * <ul>
+   * <li>0 ({@code NOBUTTON})
+   * <li>1 ({@code BUTTON1})
+   * <li>2 ({@code BUTTON2})
+   * <li>3 ({@code BUTTON3})
+   * <li>4
+   * <li>5
+   * </ul>
+   * <p>
+   * Note: If support for extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled()
+   * disabled} by Java then the AWT event subsystem does not produce mouse events for the extended
+   * mouse buttons. So it is not expected that this method returns anything except {@code NOBUTTON},
+   * {@code BUTTON1}, {@code BUTTON2}, {@code BUTTON3}.
+   *
+   * @return one of the values from 0 to {@link java.awt.MouseInfo#getNumberOfButtons()
+   *         MouseInfo.getNumberOfButtons()} if support for the extended mouse buttons is
+   *         {@link Toolkit#areExtraMouseButtonsEnabled() enabled} by Java. That range includes
+   *         {@code NOBUTTON}, {@code BUTTON1}, {@code BUTTON2}, {@code BUTTON3}; <br>
+   *         {@code NOBUTTON}, {@code BUTTON1}, {@code BUTTON2} or {@code BUTTON3} if support for
+   *         the extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() disabled} by
+   *         Java
+   * @since 1.4
+   * @see Toolkit#areExtraMouseButtonsEnabled()
+   * @see java.awt.MouseInfo#getNumberOfButtons()
+   * @see #MouseEvent(Component, int, long, int, int, int, int, int, int, boolean, int)
+   * @see InputEvent#getMaskForButton(int)
+   */
+  public int getButton() {
+    switch (type) {
+      case SWING:
+        return swing.getButton();
+      case FX_MOUSE:
+        switch (fx.getButton()) {
+          case NONE:
+            return 0;
+          case PRIMARY:
+            return 1;
+          case SECONDARY:
+            return 2;
+          case MIDDLE:
+            return 3;
+        }
+      case FX_SCROLL:
+        return 3;
+    }
+    return 0;
+  }
+
+  public Object getSource() {
+    switch (type) {
+      case SWING:
+        return swing.getSource();
+      case FX_MOUSE:
+        return fx.getSource();
+      case FX_SCROLL:
+        return scrollfx.getSource();
+    }
+    return null;
+  }
+
+  public boolean isMouseWheelEvent() {
+    switch (type) {
+      case SWING:
+        return swing instanceof MouseWheelEvent;
+      case FX_MOUSE:
+        return false;
+      case FX_SCROLL:
+        return true;
+    }
+    return false;
+  }
+
+  public double getWheelRotation() {
+    switch (type) {
+      case SWING:
+        if (isMouseWheelEvent())
+          return ((MouseWheelEvent) swing).getPreciseWheelRotation();
+        else
+          return 0;
+      case FX_SCROLL:
+        return scrollfx.getDeltaY();
+    }
+    return 0;
+  }
+
+  public void consume() {
+    switch (type) {
+      case SWING:
+        swing.consume();
+        break;
+      case FX_MOUSE:
+        fx.consume();
+        break;
+      case FX_SCROLL:
+        scrollfx.consume();
+        break;
+    }
+
+  }
+
+public Point2D getPoint() {
+	return new Point2D.Double(getX(), getY());
+}
+
+
+}

--- a/src/main/java/io/github/mzmine/chartbasics/listener/AxesRangeChangedListener.java
+++ b/src/main/java/io/github/mzmine/chartbasics/listener/AxesRangeChangedListener.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.listener;
+
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.event.AxisChangeEvent;
+import org.jfree.chart.event.AxisChangeListener;
+import org.jfree.data.Range;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+
+/**
+ * Listener for multiple axes
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public abstract class AxesRangeChangedListener implements AxisChangeListener {
+
+  // last lower / upper range
+  private ValueAxis[] axis;
+  private Range[] lastRange = null;
+  private ChartViewWrapper chart;
+
+  /**
+   * Creates no listeners. Needs to by notified by external AxisRangeChangedListeners
+   */
+  public AxesRangeChangedListener(int axiscount) {
+    axis = new ValueAxis[axiscount];
+    lastRange = new Range[axiscount];
+  }
+
+  /**
+   * Creates two axisrangechangedlistener for the Domain and Range axis
+   * 
+   * @param cp
+   */
+  public AxesRangeChangedListener(ChartViewWrapper cp) {
+    this(2);
+    chart = cp;
+    if (chart != null && chart.getChart() != null) {
+      chart.getChart().getXYPlot().getDomainAxis().addChangeListener(this);
+      chart.getChart().getXYPlot().getRangeAxis().addChangeListener(this);
+    }
+  }
+
+  @Override
+  public void axisChanged(AxisChangeEvent e) {
+    ValueAxis a = (ValueAxis) e.getAxis();
+    Range r = a.getRange();
+
+    boolean found = false;
+    int i = 0;
+    for (i = 0; i < axis.length && !found; i++) {
+      // get index of axis
+      if (axis[i] == null)
+        break;
+      if (a.equals(axis[i])) {
+        found = true;
+        break;
+      }
+    }
+    if (i >= axis.length)
+      i = axis.length - 1;
+    // insert if not found
+    if (!found) {
+      axis[i] = a;
+    }
+
+    if (r != null && (lastRange[i] == null || !r.equals(lastRange[i]))) {
+      // range has changed
+      axesRangeChanged(chart, a, lastRange[i], r);
+    }
+    lastRange[i] = r;
+  }
+
+  /**
+   * only if axis range has changed
+   * 
+   * @param axis
+   * @param lastR
+   * @param newR
+   */
+  public abstract void axesRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+      Range newR);
+}

--- a/src/main/java/io/github/mzmine/chartbasics/listener/AxisRangeChangedListener.java
+++ b/src/main/java/io/github/mzmine/chartbasics/listener/AxisRangeChangedListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.listener;
+
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.event.AxisChangeEvent;
+import org.jfree.chart.event.AxisChangeListener;
+import org.jfree.data.Range;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+
+public abstract class AxisRangeChangedListener implements AxisChangeListener {
+
+  // last lower / upper range
+  private Range lastRange = null;
+  private ChartViewWrapper chart;
+
+  public AxisRangeChangedListener(ChartViewWrapper cp) {
+    chart = cp;
+  }
+
+  @Override
+  public void axisChanged(AxisChangeEvent e) {
+    ValueAxis a = (ValueAxis) e.getAxis();
+    Range r = a.getRange();
+
+    if (r != null && (lastRange == null || !r.equals(lastRange))) {
+      // range has changed
+      axisRangeChanged(chart, a, lastRange, r);
+    }
+    lastRange = r;
+  }
+
+  /**
+   * only if axis range has changed
+   * 
+   * @param axis
+   * @param lastR
+   * @param newR
+   */
+  public abstract void axisRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR,
+      Range newR);
+}

--- a/src/main/java/io/github/mzmine/chartbasics/listener/ZoomHistory.java
+++ b/src/main/java/io/github/mzmine/chartbasics/listener/ZoomHistory.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2006-2018 The MZmine 2 Development Team
+ * 
+ * This file is part of MZmine 2.
+ * 
+ * MZmine 2 is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine 2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine 2; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package net.sf.mzmine.chartbasics.listener;
+
+import java.util.LinkedList;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.fx.ChartViewer;
+import org.jfree.data.Range;
+import net.sf.mzmine.chartbasics.gui.wrapper.ChartViewWrapper;
+
+/**
+ * The ZoomHistory stores all zoom states which are active for at least 1 second. It allows to jump
+ * to previous and next states. To obtain the ZoomHistory object from any ChartPanel use:
+ * 
+ * <pre>
+ * {@code (ZoomHistory) chartPanel.getClientProperty(ZoomHistory.PROPERTY_NAME)}
+ * </pre>
+ * 
+ * @author Robin Schmid (robinschmid@uni-muenster.de)
+ */
+public class ZoomHistory extends AxesRangeChangedListener implements Runnable {
+
+  public static final String PROPERTY_NAME = "ZOOM_HISTORY";
+
+  // history for Range[domain-, range-axis]
+  // newest first
+  private LinkedList<Range[]> history;
+  private int currentI = 0;
+  private int maxSize = 0;
+
+  // latest event
+  private Range[] newRange;
+  private Thread thread;
+  private boolean isRunning = false;
+
+  // last change
+  private static final long MIN_TIME_DIFF = 1000;
+  private long lastChangeTime = 0;
+
+  /**
+   * Creates a ZoomHistory for the given ChartPanel as a ClientProperty. The history collects all
+   * zoom states that are active for at least 1 second. It allows to jump to previous and next zoom
+   * states. To obtain the ZoomHistory object from any ChartPanel use:
+   * 
+   * <pre>
+   * {@code (ZoomHistory) chartPanel.getClientProperty(ZoomHistory.PROPERTY_NAME)}
+   * </pre>
+   * 
+   * @param cp
+   * @param maxSize
+   */
+  public ZoomHistory(ChartPanel cp, int maxSize) {
+    this(new ChartViewWrapper(cp), maxSize);
+  }
+
+  /**
+   * Creates a ZoomHistory for the given ChartPanel as a ClientProperty. The history collects all
+   * zoom states that are active for at least 1 second. It allows to jump to previous and next zoom
+   * states. To obtain the ZoomHistory object from any ChartPanel use:
+   * 
+   * <pre>
+   * {@code (ZoomHistory) chartPanel.getClientProperty(ZoomHistory.PROPERTY_NAME)}
+   * </pre>
+   * 
+   * @param cp
+   * @param maxSize
+   */
+  public ZoomHistory(ChartViewer cp, int maxSize) {
+    this(new ChartViewWrapper(cp), maxSize);
+  }
+
+  /**
+   * Creates a ZoomHistory for the given ChartPanel as a ClientProperty. The history collects all
+   * zoom states that are active for at least 1 second. It allows to jump to previous and next zoom
+   * states. To obtain the ZoomHistory object from any ChartPanel use:
+   * 
+   * <pre>
+   * {@code (ZoomHistory) chartPanel.getClientProperty(ZoomHistory.PROPERTY_NAME)}
+   * </pre>
+   * 
+   * @param cp
+   * @param maxSize
+   */
+  public ZoomHistory(ChartViewWrapper cp, int maxSize) {
+    super(cp);
+    cp.setZoomHistory(this);
+    history = new LinkedList<Range[]>();
+    // max
+    this.maxSize = maxSize;
+  }
+
+  @Override
+  public void axesRangeChanged(ChartViewWrapper chart, ValueAxis axis, Range lastR, Range newR) {
+    // ranges
+    Range dom = chart.getChart().getXYPlot().getDomainAxis().getRange();
+    Range ran = chart.getChart().getXYPlot().getRangeAxis().getRange();
+    newRange = new Range[] {dom, ran};
+
+    // set time
+    lastChangeTime = System.nanoTime();
+
+    if (!isRunning) {
+      thread = new Thread(this);
+      thread.start();
+      isRunning = true;
+    }
+  }
+
+  @Override
+  public void run() {
+    Thread thisThread = Thread.currentThread();
+    while (thisThread == thread) {
+      // greater than time limit?
+      long ctime = System.nanoTime();
+      if ((ctime - lastChangeTime) / 1000000 >= MIN_TIME_DIFF) {
+        //
+        handleLatestEvent();
+        // end
+        isRunning = false;
+        break;
+      }
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * jump in history or add new
+   */
+  private void handleLatestEvent() {
+    // is already in linked list?
+    boolean found = false;
+    for (int i = 0; i < history.size() && !found; i++) {
+      Range[] r = history.get(i);
+      if (newRange[0].equals(r[0]) && newRange[1].equals(r[1])) {
+        found = true;
+        currentI = i;
+      }
+    }
+    if (!found) {
+      // remove all history objects 0 to currentI-1
+      for (int i = 0; i < currentI; i++)
+        history.removeFirst();
+      history.addFirst(newRange);
+
+      if (history.size() > maxSize)
+        history.removeLast();
+      currentI = 0;
+    }
+  }
+
+  /**
+   * Current zoom range
+   * 
+   * @return
+   */
+  public Range[] getCurrentRange() {
+    if (history.isEmpty())
+      return null;
+    return history.get(currentI);
+  }
+
+  /**
+   * Previous zoom range without changing the active state of the history
+   * 
+   * @return
+   */
+  public Range[] getPreviousRange() {
+    if (history.isEmpty() || currentI + 1 >= getSize())
+      return null;
+    return history.get(currentI + 1);
+  }
+
+  /**
+   * Next zoom range without changing the active state of the history
+   * 
+   * @return
+   */
+  public Range[] getNextRange() {
+    if (history.isEmpty() || currentI - 1 < 0)
+      return null;
+    return history.get(currentI - 1);
+  }
+
+  /**
+   * Jump to previous zoom range (change current state)
+   * 
+   * @return
+   */
+  public Range[] setPreviousPoint() {
+    currentI++;
+    if (currentI >= getSize())
+      currentI = getSize() - 1;
+    return getCurrentRange();
+  }
+
+  /**
+   * Jump to next zoom range (change current state)
+   * 
+   * @return
+   */
+  public Range[] setNextPoint() {
+    currentI--;
+    if (currentI < 0)
+      currentI = 0;
+    return getCurrentRange();
+  }
+
+  /**
+   * Might want to clear the history after completing the creation of a chart
+   */
+  public void clear() {
+    stopRunningUpdates();
+    history.clear();
+  }
+
+  /**
+   * Stops the threads run method that updates the history on axes changed events
+   */
+  public void stopRunningUpdates() {
+    thread = null;
+    isRunning = false;
+  }
+
+  public LinkedList<Range[]> getHistory() {
+    return history;
+  }
+
+  public int getSize() {
+    return history.size();
+  }
+
+  public int getCurrentIndex() {
+    return currentI;
+  }
+}


### PR DESCRIPTION
Hey Tomas,

as MZmine 3 will rely on JavaFX, I made the ChartGestures work with both swing and javaFX. The framework specific classes (only a few) are organised in the gui packages. Wrappers for MouseEvents and ChartViewer/ChartPanel connect swing and fx in a way that the same ChartGestureHandlers can be used for both. Another important addition, enables ChartGestures for CombinedXYPlots.

The demos are important to quickly test new functions. I am also going to add this to MZmine 2 so that every contributer can use the newest version.

Still missing:
- CategoryPlot ChartGestures
- ZoomHistory for CombinedPlots

Best regards,
Robin